### PR TITLE
Update docker image for api-umbrella

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,7 +38,7 @@ Register a new admin account. The first user will become Admin.
 * API Key: from step #6
 * Auth Token: from step #7
 * Base URL: "https://YOUR_SITE_DOMAIN:3002/api-umbrella/"
-* Elasticsearch: "http://YOUR_SITE_DOMAIN:14002"
+* Elasticsearch: "http://elasticsearch.docker:9200"
 11. Add API backend https://YOUR_SITE_DOMAIN/api/new
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,11 @@ services:
       - "3000:80"
     depends_on:
       - mongo
+      - ssl
+    links:
+      - elasticsearch:elasticsearch.docker
   apiumbrella:
-    image: nrel/api-umbrella:0.12.0
+    image: nrel/api-umbrella:0.13.0
     restart: always
     volumes:
       - ./docker/api-umbrella/config:/etc/api-umbrella
@@ -20,9 +23,10 @@ services:
     ports:
       - "3001:3001"
       - "3002:3002"
-      - "14002:14002"
     depends_on:
       - ssl
+    links:
+      - elasticsearch:elasticsearch.docker
   mongo:
     restart: always
     image: mongo:3.2.6
@@ -41,9 +45,14 @@ services:
       - letsencrypt:/etc/letsencrypt
       - letsencrypt_backups:/var/lib/letsencrypt
       - dhparam_cache:/cache
-    depends_on:
-      - apinf
+  elasticsearch:
+    image: elasticsearch:2.4
+    restart: always
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+    command: elasticsearch -Des.index.max_result_window=50000
 volumes:
     letsencrypt: {}
     letsencrypt_backups: {}
     dhparam_cache: {}
+    elasticsearch_data: {}

--- a/docker/api-umbrella/config/api-umbrella.yml.example
+++ b/docker/api-umbrella/config/api-umbrella.yml.example
@@ -2,7 +2,6 @@ http_port: 3001
 https_port: 3002
 services:
   - general_db
-  - log_db
   - router
   - web
 web:
@@ -21,8 +20,9 @@ web:
         client_id:
         client_secret:
 elasticsearch:
+  api_version: 2
   hosts:
-    - http://127.0.0.1:14002
+    - http://elasticsearch.docker:9200
 mongodb:
   url: mongodb://127.0.0.1:14001/api_umbrella_db
 nginx:


### PR DESCRIPTION
* Update docker image for api-umbrella to version 0.13.0
* Split ElasticSearch fro api-umbrella to separate container.
* Make ElasticSearch available only from private docker network (between containers). 

Closes #1249