### PR TITLE
Feature/disable api key bootstrap switch

### DIFF
--- a/core/lib/i18n/en.i18n.json
+++ b/core/lib/i18n/en.i18n.json
@@ -464,7 +464,7 @@
       "apiUmbrella": {
         "settings": {
           "disable_api_key": {
-            "label": "Disable API key"
+            "label": "API key check"
           }
         }
       }

--- a/core/lib/i18n/en.i18n.json
+++ b/core/lib/i18n/en.i18n.json
@@ -378,41 +378,6 @@
         }
       }
     },
-    "apiWizard_backendInformation": {
-      "backend_protocol": {
-        "label": "Protocol"
-      },
-      "backend_host": {
-        "label": "Host",
-        "placeholder": "Enter the remote host name for this API backend"
-      },
-      "backend_port": {
-        "label": "Port"
-      }
-    },
-    "apiWizard_baseInformation": {
-      "name": {
-        "label": "Name",
-        "placeholder": "Enter a name for this API Backend"
-      },
-      "description": {
-        "label": "Description",
-        "placeholder": "Describe this API Backend"
-      }
-    },
-    "apiWizard_prefixesInformation": {
-      "url_matches": {
-        "label": "URL Matching strings",
-        "frontend_prefix": {
-          "label": "Frontend prefix",
-          "placeholder": "Enter a string to use as the path to access this API Backend"
-        },
-        "backend_prefix": {
-          "label": "Backend prefix",
-          "placeholder": "Enter a string to be added to each backend request"
-        }
-      }
-    },
     "backlog": {
       "title": {
         "label": "Title",

--- a/proxy_backends/client/form/form.js
+++ b/proxy_backends/client/form/form.js
@@ -14,7 +14,9 @@ import 'urijs';
 Template.proxyBackend.onRendered(() => {
   // Make Disable API Key field easier to use
     // Fixes browser rendering issue
-  $("[name='apiUmbrella.settings.disable_api_key']").bootstrapSwitch();
+  $("[name='apiUmbrella.settings.disable_api_key']").bootstrapSwitch({
+    size: 'mini',
+  });
 });
 
 Template.proxyBackend.helpers({

--- a/proxy_backends/client/form/form.js
+++ b/proxy_backends/client/form/form.js
@@ -16,6 +16,7 @@ Template.proxyBackend.onRendered(() => {
     // Fixes browser rendering issue
   $("[name='apiUmbrella.settings.disable_api_key']").bootstrapSwitch({
     size: 'mini',
+    inverse: true,
   });
 });
 

--- a/proxy_backends/client/form/form.js
+++ b/proxy_backends/client/form/form.js
@@ -11,6 +11,12 @@ import { Proxies } from '/proxies/collection';
 // NPM import
 import 'urijs';
 
+Template.proxyBackend.onRendered(() => {
+  // Make Disable API Key field easier to use
+    // Fixes browser rendering issue
+  $("[name='apiUmbrella.settings.disable_api_key']").bootstrapSwitch();
+});
+
 Template.proxyBackend.helpers({
   apiHost () {
     // Get one proxy from the Proxies collection

--- a/proxy_backends/collection/apiUmbrellaSchema.js
+++ b/proxy_backends/collection/apiUmbrellaSchema.js
@@ -3,13 +3,16 @@ import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 import { proxyBasePathRegEx, apiBasePathRegEx } from './regex';
 
 
-const Settings = new SimpleSchema({
+const SettingsSchema = new SimpleSchema({
   'disable_api_key': {
     type: Boolean,
     optional: true,
     defaultValue: false,
   },
 });
+
+// Internationalize settings schema texts
+SettingsSchema.i18n('schemas.ProxyBackends.apiUmbrella.settings');
 
 const ApiUmbrellaSchema = new SimpleSchema({
   id: {
@@ -75,9 +78,12 @@ const ApiUmbrellaSchema = new SimpleSchema({
     label: 'API port',
   },
   settings: {
-    type: Settings,
+    type: SettingsSchema,
     optional: true,
   },
 });
+
+// Internationalize API Umbrella schema texts
+ApiUmbrellaSchema.i18n('schemas.ProxyBackends.apiUmbrella');
 
 export { ApiUmbrellaSchema };

--- a/proxy_backends/collection/schema.js
+++ b/proxy_backends/collection/schema.js
@@ -14,4 +14,8 @@ ProxyBackends.schema = new SimpleSchema({
   },
 });
 
+// Internationalize schema texts
+ProxyBackends.schema.i18n('schemas.ProxyBackends');
+
+// Attach schema to collection
 ProxyBackends.attachSchema(ProxyBackends.schema);


### PR DESCRIPTION
Closes #1653 
Closes #1656 
Closes #1658

# Changes
- Add Bootstrap Switch toggle to *API key check* field
- Change *API key check* field label to be more semantic
- Add i18n support to ProxyBackends schema and related sub-schemas
  - apiUmbrella
    - settings
- Remove API Wizard schema i18n strings