### PR TITLE
Api monitoring v 2

### DIFF
--- a/apis/client/add/add.html
+++ b/apis/client/add/add.html
@@ -2,7 +2,7 @@
   <div class="container">
     {{# autoForm collection=ApisCollection id="addApiForm" type="insert" }}
       <!--invisible auto-value field-->
-      {{> afQuickField name='status_code' value="-1" type="hidden"}}
+      {{> afQuickField name='latestMonitoringStatusCode' value="-1" type="hidden"}}
       <fieldset>
         <legend>Add an API</legend>
         {{> afQuickField name='name' }}

--- a/apis/client/add/add.html
+++ b/apis/client/add/add.html
@@ -1,6 +1,8 @@
 <template name="addApi">
   <div class="container">
     {{# autoForm collection=ApisCollection id="addApiForm" type="insert" }}
+      <!--invisible auto-value field-->
+      {{> afQuickField name='status_code' value="-1" type="hidden"}}
       <fieldset>
         <legend>Add an API</legend>
         {{> afQuickField name='name' }}

--- a/apis/client/view/settings/settings.html
+++ b/apis/client/view/settings/settings.html
@@ -30,6 +30,7 @@
       {{/ autoForm }}
     </div>
   </div>
+  {{> apiMonitoring api=api}}
   <div class="panel panel-danger">
     <div class="panel-heading">
       <h2 class="panel-title">

--- a/apis/client/view/status/convert_status_code.js
+++ b/apis/client/view/status/convert_status_code.js
@@ -1,0 +1,69 @@
+// Meteor packages import
+import { TAPi18n } from 'meteor/tap:i18n';
+
+// Check which status code is received
+// and set class name and status text depending on it
+export function convertStatusCode (serverStatusCode) {
+  // Init variables
+  let className = '';
+  let statusText = '';
+
+  // Computed an api status for Switch
+  const apiStatus = Math.floor(serverStatusCode / 100);
+
+  switch (apiStatus) {
+    // Temporary status: monitoring is enabled but real status code is unknown
+    case 0:
+      className = 'api-status-color';
+      statusText = TAPi18n.__('viewApiStatus_statusMessage_Loading');
+      break;
+    // Informational status code
+    case 1:
+      className = 'status-info';
+      statusText = `
+          ${TAPi18n.__('viewApiStatus_statusMessage_ErrorCodeText')}
+          ${serverStatusCode}.
+          ${TAPi18n.__('viewApiStatus_statusMessage_Informational')}
+          `;
+      break;
+    // Success status code
+    case 2:
+      className = 'status-success';
+      statusText = TAPi18n.__('viewApiStatus_statusMessage_Success');
+      break;
+    // Redirection code
+    case 3:
+      className = 'status-success';
+      statusText = `
+          ${TAPi18n.__('viewApiStatus_statusMessage_ErrorCodeText')}
+          ${serverStatusCode}.
+          ${TAPi18n.__('viewApiStatus_statusMessage_RedirectError')}
+          `;
+      break;
+    // Client Error code
+    case 4:
+      className = 'status-warning';
+      statusText = `
+          ${TAPi18n.__('viewApiStatus_statusMessage_ErrorCodeText')}
+          ${serverStatusCode}.
+          ${TAPi18n.__('viewApiStatus_statusMessage_ClientError')}
+          `;
+      break;
+    // Server Error code
+    case 5:
+      className = 'status-danger';
+      statusText = `
+          ${TAPi18n.__('viewApiStatus_statusMessage_ErrorCodeText')}
+          ${serverStatusCode}.
+          ${TAPi18n.__('viewApiStatus_statusMessage_ServerError')}
+          `;
+      break;
+    // The api monitoring is disable
+    default:
+      className = 'invisible';
+      break;
+  }
+
+  return { className, statusText };
+}
+

--- a/apis/client/view/status/convert_status_code.js
+++ b/apis/client/view/status/convert_status_code.js
@@ -3,7 +3,7 @@ import { TAPi18n } from 'meteor/tap:i18n';
 
 // Check which status code is received
 // and set class name and status text depending on it
-export function convertStatusCode (serverStatusCode) {
+export default function convertStatusCode (serverStatusCode) {
   // Init variables
   let className = '';
   let statusText = '';
@@ -14,7 +14,7 @@ export function convertStatusCode (serverStatusCode) {
   switch (apiStatus) {
     // Temporary status: monitoring is enabled but real status code is unknown
     case 0:
-      className = 'api-status-color';
+      className = 'status-wait';
       statusText = TAPi18n.__('viewApiStatus_statusMessage_Loading');
       break;
     // Informational status code

--- a/apis/client/view/status/status.html
+++ b/apis/client/view/status/status.html
@@ -3,7 +3,6 @@
     class="api-status-indicator-{{ api._id }} api-status-color"
     data-toggle="tooltip"
     data-placement="top"
-    title="Loading.."
-    style="height:{{ width }}em; width:{{ width }}em;"
+    style="height:{{width}}em; width:{{width}}em;"
     ></div>
 </template>

--- a/apis/client/view/status/status.html
+++ b/apis/client/view/status/status.html
@@ -1,8 +1,9 @@
 <template name="viewApiStatus" >
   <div
-    class="api-status-indicator-{{ api._id }} api-status-color"
+    class="{{ classList }}"
     data-toggle="tooltip"
     data-placement="top"
-    style="height:{{width}}em; width:{{width}}em;"
-    ></div>
+    data-original-title="{{ originalTitle }}"
+    style="height:{{width}}em; width:{{width}}em;">
+  </div>
 </template>

--- a/apis/client/view/status/status.js
+++ b/apis/client/view/status/status.js
@@ -1,5 +1,8 @@
-// Meteor imports
+// Meteor packages import
 import { Template } from 'meteor/templating';
+
+// APINF import
+import { convertStatusCode } from '/apis/client/view/status/convert_status_code';
 
 Template.viewApiStatus.onCreated(function () {
   // Create reference to instance
@@ -9,61 +12,21 @@ Template.viewApiStatus.onCreated(function () {
   const api = instance.data.api;
 
   // attaches function to template instance to be able to call it in outside
-  instance.getApiStatus = (url) => {
-    Meteor.call('getApiStatus', url, (err, status) => {
-      // Status object contents:
-      // status = {
-      //   statusCode      : <integer>,
-      //   responseContext : <object>,
-      //   errorMessage    : <String>
-      // };
+  instance.apiStatus = () => {
+    // Recognize status code
+    const status = convertStatusCode(api.status_code);
 
-      // Init indicator element
-      const apiStatusIndicator = $('.api-status-indicator-' + api._id);
+    // Get class name and status text for indicator
+    const className = status.className;
+    const statusText = status.statusText;
 
-      // Init regEx for status codes
-      const success = /^2[0-9][0-9]$/;
-      const redirect = /^3[0-9][0-9]$/;
-      const clientErr = /^4[0-9][0-9]$/;
-      const serverErr = /^5[0-9][0-9]$/;
+    // Init indicator element
+    const apiStatusIndicator = $('.api-status-indicator-' + api._id);
 
-      let className = '';
-      let statusText = '';
-
-      // Check which status code is received
-      // and display text depending on it
-      if (success.test(status.code)) {
-        className = 'status-success';
-        statusText = `
-          ${TAPi18n.__('viewApiStatus_statusMessage_Success')}
-          `;
-      } else if (redirect.test(status.code)) {
-        className = 'status-success';
-        statusText = `
-          ${TAPi18n.__('viewApiStatus_statusMessage_ErrorCodeText')}
-          ${status.code}.
-          ${TAPi18n.__('viewApiStatus_statusMessage_RedirectError')}
-        `;
-      } else if (clientErr.test(status.code)) {
-        className = 'status-warning';
-        statusText = `
-          ${TAPi18n.__('viewApiStatus_statusMessage_ErrorCodeText')}
-          ${status.code}.
-          ${TAPi18n.__('viewApiStatus_statusMessage_ClientError')}
-        `;
-      } else if (serverErr.test(status.code)) {
-        className = 'alert-danger';
-        statusText = `
-          ${TAPi18n.__('viewApiStatus_statusMessage_ErrorCodeText')}
-          ${status.code}.
-          ${TAPi18n.__('viewApiStatus_statusMessage_ServerError')}
-        `;
-      }
-
-      apiStatusIndicator
-        .addClass(className)
-        .attr('data-original-title', statusText);
-    });
+    // Set indicator element
+    apiStatusIndicator
+      .addClass(className)
+      .attr('data-original-title', statusText);
   };
 });
 
@@ -71,21 +34,9 @@ Template.viewApiStatus.onRendered(function () {
   // Get reference to template instance
   const instance = this;
 
-  // Get API Backend from instance data context
-  const api = instance.data.api;
+  // call the function that updates status
+  instance.apiStatus();
 
-  // Make sure URL is available, to prevent console error
-  if (api && api.url) {
-    // create request url based on API URL
-    const url = api.url;
-
-    // call the function that updates status
-    instance.getApiStatus(url);
-
-    // Init tooltip
-    $('[data-toggle="tooltip"]').tooltip();
-  } else {
-    // Hide the status indicator
-    $('.api-status-indicator-' + api._id).hide();
-  }
+  // Init tooltip
+  $('[data-toggle="tooltip"]').tooltip();
 });

--- a/apis/client/view/status/status.js
+++ b/apis/client/view/status/status.js
@@ -2,41 +2,35 @@
 import { Template } from 'meteor/templating';
 
 // APINF import
-import { convertStatusCode } from '/apis/client/view/status/convert_status_code';
+import convertStatusCode from './convert_status_code';
 
-Template.viewApiStatus.onCreated(function () {
-  // Create reference to instance
-  const instance = this;
-
-  // Get API Backend from instance data context
-  const api = instance.data.api;
-
-  // attaches function to template instance to be able to call it in outside
-  instance.apiStatus = () => {
-    // Recognize status code
-    const status = convertStatusCode(api.status_code);
-
-    // Get class name and status text for indicator
-    const className = status.className;
-    const statusText = status.statusText;
-
-    // Init indicator element
-    const apiStatusIndicator = $('.api-status-indicator-' + api._id);
-
-    // Set indicator element
-    apiStatusIndicator
-      .addClass(className)
-      .attr('data-original-title', statusText);
-  };
-});
-
-Template.viewApiStatus.onRendered(function () {
-  // Get reference to template instance
-  const instance = this;
-
-  // call the function that updates status
-  instance.apiStatus();
-
+Template.viewApiStatus.onRendered(() => {
   // Init tooltip
   $('[data-toggle="tooltip"]').tooltip();
+});
+
+Template.viewApiStatus.helpers({
+  classList () {
+    // Get api
+    const api = Template.currentData().api;
+    // Get class name depending on the api status code
+    const { className } = convertStatusCode(api.latestMonitoringStatusCode);
+
+    // Create a new line using join
+    return [
+      `api-status-indicator-${api._id}`,
+      'icon-indicator',
+      className,
+    ].join(' ');
+  },
+
+  originalTitle () {
+    // Get api
+    const api = Template.currentData().api;
+
+    // Get original title depending on the api status code
+    const { statusText } = convertStatusCode(api.latestMonitoringStatusCode);
+
+    return statusText;
+  },
 });

--- a/apis/client/view/status/status.less
+++ b/apis/client/view/status/status.less
@@ -1,15 +1,17 @@
 /* Bootstrap */
 @import "/core/client/style/bootstrap-variables.less";
 
-.api-status-color {
+.icon-indicator {
   display: inline-block;
-  background-color: #a0a0a0;
   border-radius: 50%;
   -moz-border-radius: 50%;
   -webkit-border-radius: 50%;
   margin-bottom: 0.1em;
 }
 
+.status-wait {
+  background-color: #a0a0a0;
+}
 .status-success {
   background-color: @brand-success;
 }

--- a/apis/client/view/status/status.less
+++ b/apis/client/view/status/status.less
@@ -21,3 +21,7 @@
 .status-danger {
   background-color: @brand-danger;
 }
+
+.status-info {
+  background-color: @brand-info;
+}

--- a/apis/collection/schema.js
+++ b/apis/collection/schema.js
@@ -30,7 +30,7 @@ Apis.schema = new SimpleSchema({
     type: String,
     optional: true,
   },
-  status_code: {
+  latestMonitoringStatusCode: {
     type: String
   },
   apiLogoFileId: {

--- a/apis/collection/schema.js
+++ b/apis/collection/schema.js
@@ -30,6 +30,9 @@ Apis.schema = new SimpleSchema({
     type: String,
     optional: true,
   },
+  status_code: {
+    type: String
+  },
   apiLogoFileId: {
     type: String,
     optional: true,
@@ -37,6 +40,10 @@ Apis.schema = new SimpleSchema({
   authorizedUserIds: {
     type: [String],
     optional: true,
+  },
+  monitoringId: {
+    type: String,
+    optional: true
   },
   documentation_link: {
     type: String,

--- a/apis/server/methods/delete.js
+++ b/apis/server/methods/delete.js
@@ -9,12 +9,16 @@ import { ApiMetadata } from '/metadata/collection';
 import { DocumentationFiles } from '/documentation/collection/collection';
 import { Feedback } from '/feedback/collection';
 import { ProxyBackends } from '/proxy_backends/collection';
+import { Monitoring } from '/monitoring/collection';
 
 Meteor.methods({
   // Remove API backend and related items
   removeApi (apiId) {
     // Remove API doc
     Meteor.call('removeApiDoc', apiId);
+
+    // Stop the api monitoring if it's enabled
+    Meteor.call('stopCron', apiBackendId);
 
     // Remove backlog items
     ApiBacklogItems.remove({ apiId });
@@ -33,6 +37,9 @@ Meteor.methods({
       // Delete proxyBackend
       Meteor.call('deleteProxyBackend', proxyBackend);
     }
+
+    // Remove monitoring settings
+    Monitoring.remove({ 'apiId': apiBackendId });
 
     // Finally remove the API
     Apis.remove(apiId);

--- a/apis/server/methods/delete.js
+++ b/apis/server/methods/delete.js
@@ -8,8 +8,8 @@ import { ApiBacklogItems } from '/backlog/collection';
 import { ApiMetadata } from '/metadata/collection';
 import { DocumentationFiles } from '/documentation/collection/collection';
 import { Feedback } from '/feedback/collection';
+import { MonitoringSettings, MonitoringData } from '/monitoring/collection';
 import { ProxyBackends } from '/proxy_backends/collection';
-import { Monitoring } from '/monitoring/collection';
 
 Meteor.methods({
   // Remove API backend and related items
@@ -18,7 +18,16 @@ Meteor.methods({
     Meteor.call('removeApiDoc', apiId);
 
     // Stop the api monitoring if it's enabled
-    Meteor.call('stopCron', apiBackendId);
+    Meteor.call('stopCron', apiId);
+
+    // Get monitoring Settings
+    const monitoring =  MonitoringSettings.findOne({ apiId });
+
+    // Check if API has monitoring
+    if (monitoring) {
+      // Remove Monitoring Settings and Monitoring Data
+      Meteor.call('removeMonitoring', apiId)
+    }
 
     // Remove backlog items
     ApiBacklogItems.remove({ apiId });
@@ -38,9 +47,6 @@ Meteor.methods({
       Meteor.call('deleteProxyBackend', proxyBackend);
     }
 
-    // Remove monitoring settings
-    Monitoring.remove({ 'apiId': apiBackendId });
-
     // Finally remove the API
     Apis.remove(apiId);
   },
@@ -55,4 +61,11 @@ Meteor.methods({
     // Remove documentation object
     DocumentationFiles.remove(objectId);
   },
+  removeMonitoring (apiId) {
+    // Remove monitoring data collection
+    MonitoringData.remove({ apiId });
+
+    // Remove monitoring settings collection
+    MonitoringSettings.remove({ apiId});
+  }
 });

--- a/apis/server/methods/status.js
+++ b/apis/server/methods/status.js
@@ -1,47 +1,24 @@
+// APINF import
+import { MonitoringData } from '/monitoring/collection';
+import { Apis } from '/apis/collection';
+
 Meteor.methods({
-  'getApiStatus': function (uri) {
-    this.unblock();
+  getApiStatus (apiId, url) {
+    // Call HTTP request
+    Meteor.http.get(url, {}, (error, result) => {
+      // Set status code
+      const serverStatusCode = result ? result.statusCode : 404;
 
-    // Init empty status object
-    const status = {
-      code: 0,
-      errorMessage: '',
-      responseContext: {},
-    };
+      // Create a monitoring data
+      const monitoringData = {
+        date: new Date(),
+      };
 
-    // Try-catch wrapper
-    // Because if requested host is not available, error is thrown
-    try {
-      // response object from GET request to api host
-      const result = Meteor.http.call('GET', uri);
+      // Update an api status
+      Apis.update(apiId, { $set: { latestMonitoringStatusCode: serverStatusCode } });
 
-      // Check result is received
-      if (result) {
-        // Get response status code
-        status.code = result.statusCode;
-
-        // Keep response object
-        status.responseContext = result;
-      }
-
-      return status;
-    } catch (error) {
-      // Got a network error, time-out or HTTP error in the 400 or 500 range.
-
-      // Check if "ECONNREFUSED" is reveived
-      if (!error.response && error.code === 'ECONNREFUSED') {
-        // Provide 404 error
-        status.code = 404;
-      } else {
-        // Keep response error code
-        // TODO: make sure this 'else' statement handles all other cases
-        // e.g. error.response or error.response.statusCode may not exist
-        status.code = error.response.statusCode;
-      }
-
-      // Keep reponse error message
-      status.errorMessage = error;
-
-      return status;
-    }
-  } });
+      // Add the monitoring data in Collection
+      MonitoringData.update({ apiId }, { $push: { responses: monitoringData } });
+    });
+  }
+});

--- a/apis/server/methods/status.js
+++ b/apis/server/methods/status.js
@@ -20,5 +20,5 @@ Meteor.methods({
       // Add the monitoring data in Collection
       MonitoringData.update({ apiId }, { $push: { responses: monitoringData } });
     });
-  }
+  },
 });

--- a/apis/server/startup.js
+++ b/apis/server/startup.js
@@ -4,4 +4,8 @@ Meteor.startup(function () {
 
   // Make sure all API backends have average ratings
   Meteor.call('setAllApiBackendAverageRatings');
+
+  // Restart all cron worker
+  Meteor.call('restartCron');
+  SyncedCron.start()
 });

--- a/catalogue/client/grid/grid.html
+++ b/catalogue/client/grid/grid.html
@@ -17,11 +17,11 @@
               {{_ "catalogueGrid_addedBy" }}
               {{ api.getApiManagersByName }}
             </span>
+          <p class="api-card-description">
             {{# if api.description }}
-            <p class="api-card-description">
               {{ api.description }}
-            </p>
             {{/ if }}
+          </p>
           </div>
           <ul class="api-card-stats list-inline">
             {{# if currentUser }}

--- a/catalogue/client/grid/grid.less
+++ b/catalogue/client/grid/grid.less
@@ -16,7 +16,7 @@
   height: 10.7em;
   margin-bottom: 1.87em;
 
-  .api-status-color {
+  .icon-indicator {
     float: right;
   }
 }

--- a/core/lib/i18n/en.i18n.json
+++ b/core/lib/i18n/en.i18n.json
@@ -111,6 +111,11 @@
   "apiSettings_visibility_text": "Make this API private or public",
   "api_backend_rating_anonymous": "Please log in to vote.",
   "apinf_usernotloggedin_error": "Could not find logged in user.",
+  "apiMonitoring_panelTitle_Monitoring": "API Monitoring",
+  "apiMonitoring_helpIcon_text": "Please provide a valid path to an endpoint to make actual API calls. API monitoring is done using HTTP requests. You can use GET method only so that accidental data insertion in your API is prevented.",
+  "apiMonitoring_saveButton_text": "Save",
+  "apiMonitoringForm_successMessage": "The API Monitoring settings are successfully saved!",
+  "apiMonitoringForm_errorMessage": "Endpoint to monitor is required",
   "apiProxy_headerText": "Proxy backend configuration",
   "backlogItem_addedByYou": "Added by you",
   "backlogItem_editButton_text": "Edit",
@@ -410,6 +415,14 @@
         "label": "Choose message type"
       }
     },
+    "monitoring": {
+      "url": {
+        "label": "Endpoint to Monitor"
+      },
+      "enabled": {
+        "label": "Enabled API Monitoring"
+      }
+    },
     "settings": {
       "apiDocumentationEditor": {
         "label": "API Documentation Editor",
@@ -570,6 +583,8 @@
   "viewApiSettigs_saveButton_text": "Save",
   "viewApiStatus_statusMessage_ClientError": "Client error.",
   "viewApiStatus_statusMessage_ErrorCodeText": "Status code:",
+  "viewApiStatus_statusMessage_Informational": "Informational.",
+  "viewApiStatus_statusMessage_Loading": "Loading...",
   "viewApiStatus_statusMessage_RedirectError": "Redirection.",
   "viewApiStatus_statusMessage_ServerError": "Server error.",
   "viewApiStatus_statusMessage_Success": "API is operating normally.",

--- a/monitoring/client/autoform.js
+++ b/monitoring/client/autoform.js
@@ -27,14 +27,13 @@ AutoForm.hooks({
           }
           // Success result
           return doc;
-        } else {
-          // Get success message translation
-          const message = TAPi18n.__('apiMonitoringForm_errorMessage');
-
-          // Alert the user of error
-          sAlert.error(message);
-          return false;
         }
+        // Get success message translation
+        const message = TAPi18n.__('apiMonitoringForm_errorMessage');
+
+        // Alert the user of error
+        sAlert.error(message);
+        return false;
       },
     },
     after: {
@@ -48,7 +47,7 @@ AutoForm.hooks({
 
           MonitoringData.insert({ apiId }, (error, id) => {
             // Linked both collections
-            MonitoringSettings.update(result, { $set: { data: id } })
+            MonitoringSettings.update(result, { $set: { data: id } });
           });
 
           // Link Monitoring collection with Apis collection
@@ -61,12 +60,11 @@ AutoForm.hooks({
     },
     onSuccess () {
       // Get update values
-      const updateFormValues = this.updateDoc ? this.updateDoc.$set : this.insertDoc ;
+      const updateFormValues = this.updateDoc ? this.updateDoc.$set : this.insertDoc;
 
       // If monitoring is enabled then get the API status immediately
       if (updateFormValues.enabled) {
         Meteor.call('getApiStatus', updateFormValues.apiId, updateFormValues.url);
-
       }
 
       // Get success message translation

--- a/monitoring/client/autoform.js
+++ b/monitoring/client/autoform.js
@@ -1,0 +1,72 @@
+// Meteor package imports
+import { Meteor } from 'meteor/meteor';
+import { sAlert } from 'meteor/juliancwirko:s-alert';
+import { TAPi18n } from 'meteor/tap:i18n';
+import { AutoForm } from 'meteor/aldeed:autoform';
+
+// Apinf import
+import { Monitoring } from '/monitoring/collection';
+import { Apis } from '/apis/collection';
+
+AutoForm.hooks({
+  apiMonitoringForm: {
+    before: {
+      update: (doc) => {
+        // Check form on validation
+        if (AutoForm.validateForm('apiMonitoringForm')) {
+          // Get new data
+          const monitoringData = doc.$set;
+          // If data was updated than enabled is false or url is updated
+          // For apply new url, cron must be restarted
+          // If enabled is false,cron must be stop too
+          Meteor.call('stopCron', monitoringData.apiId);
+
+          // Restart cron with new url
+          if (monitoringData.enabled) {
+            Meteor.call('startCron', monitoringData.apiId, monitoringData.url);
+          }
+          // Success resut
+          return doc;
+        } else {
+          // Get success message translation
+          const message = TAPi18n.__('apiMonitoringForm_errorMessage');
+
+          // Alert the user of error
+          sAlert.error(message);
+          return false;
+        }
+      },
+    },
+    after: {
+      insert: (error, result) => {
+        if (result) {
+          // Get monitoring document
+          const monitoring = Monitoring.findOne({ _id: result });
+
+          // Get api id
+          const apiId = monitoring.apiId;
+
+          // Link Monitoring collection with Apis collection
+          Apis.update(apiId, { $set: { monitoringId: result } });
+
+          // Start Cron
+          Meteor.call('startCron', apiId, monitoring.url);
+        }
+      },
+    },
+    onSuccess () {
+      // Get success message translation
+      const message = TAPi18n.__('apiMonitoringForm_successMessage');
+
+      // Alert the user of success
+      sAlert.success(message);
+    },
+    onError () {
+      // Get success message translation
+      const message = TAPi18n.__('apiMonitoringForm_errorMessage');
+
+      // Alert the user of error
+      sAlert.error(message);
+    },
+  },
+});

--- a/monitoring/client/monitoring.css
+++ b/monitoring/client/monitoring.css
@@ -1,5 +1,0 @@
-.disabled-input {
-    margin-right: 10px;
-    width: 80px;
-    background-color: #eee;
-}

--- a/monitoring/client/monitoring.css
+++ b/monitoring/client/monitoring.css
@@ -1,0 +1,5 @@
+.disabled-input {
+    margin-right: 10px;
+    width: 80px;
+    background-color: #eee;
+}

--- a/monitoring/client/monitoring.html
+++ b/monitoring/client/monitoring.html
@@ -27,14 +27,7 @@
             {{ afFieldLabelText name='url'}} &nbsp;
           </label>
           <div class="form-group">
-            <div class="row">
-              <div class="col-sm-1">
-                <input type="text" placeholder="GET" class="form-control" readonly>
-              </div>
-              <div class="col-sm-11">
                 {{> afFieldInput name='url'}}
-              </div>
-            </div>
           </div>
         {{/if}}
         <div class="form-group">

--- a/monitoring/client/monitoring.html
+++ b/monitoring/client/monitoring.html
@@ -1,0 +1,48 @@
+<template name="apiMonitoring">
+  <div class="panel panel-default">
+    <div class="panel-heading">
+      <a
+      tabindex="0"
+      class="pull-right"
+      role="button"
+      data-toggle="popover"
+      data-placement="left"
+      data-trigger="focus"
+      data-content="{{_ "apiMonitoring_helpIcon_text" }}">
+      <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+      </a>
+      <h2 class="panel-title">
+        {{_ "apiMonitoring_panelTitle_Monitoring" }}
+      </h2>
+    </div>
+    <div class="panel-body">
+      {{# autoForm collection=monitoringCollection id="apiMonitoringForm" type=formType doc=apiMonitoringSettings}}
+        <!-- hidden field, auto-value -->
+        {{> afQuickField name='apiId' value=api._id type="hidden" }}
+
+        {{> afQuickField name='enabled'}}
+
+        {{#if afFieldValueIs name='enabled' value=true}}
+          <label for="endpoint-monitor-field">
+            {{ afFieldLabelText name='url'}} &nbsp;
+          </label>
+          <div class="form-group">
+            <div class="row">
+              <div class="col-sm-1">
+                <input type="text" placeholder="GET" class="form-control" readonly>
+              </div>
+              <div class="col-sm-11">
+                {{> afFieldInput name='url'}}
+              </div>
+            </div>
+          </div>
+        {{/if}}
+        <div class="form-group">
+          <button type="submit" class="btn btn-success" id="save-monitoring-settings">
+            {{_ "apiMonitoring_saveButton_text" }}
+          </button>
+        </div>
+      {{/autoForm}}
+    </div>
+  </div>
+</template>

--- a/monitoring/client/monitoring.html
+++ b/monitoring/client/monitoring.html
@@ -16,18 +16,19 @@
       </h2>
     </div>
     <div class="panel-body">
-      {{# autoForm collection=monitoringCollection id="apiMonitoringForm" type=formType doc=apiMonitoringSettings}}
+      {{# autoForm collection=monitoringCollection id="apiMonitoringForm" type=formType doc=apiMonitoringSettings }}
         <!-- hidden field, auto-value -->
         {{> afQuickField name='apiId' value=api._id type="hidden" }}
 
-        {{> afQuickField name='enabled'}}
+        {{> afQuickField name='enabled' }}
 
-        {{#if afFieldValueIs name='enabled' value=true}}
+        {{#if afFieldValueIs name='enabled' value=true }}
           <label for="endpoint-monitor-field">
-            {{ afFieldLabelText name='url'}} &nbsp;
+            {{ afFieldLabelText name='url' }}
+            &nbsp;
           </label>
           <div class="form-group">
-                {{> afFieldInput name='url'}}
+                {{> afFieldInput name='url' }}
           </div>
         {{/if}}
         <div class="form-group">

--- a/monitoring/client/monitoring.js
+++ b/monitoring/client/monitoring.js
@@ -2,7 +2,7 @@
 import { Template } from 'meteor/templating';
 
 // Apinf import
-import { Monitoring } from '/monitoring/collection';
+import { MonitoringSettings } from '/monitoring/collection';
 
 Template.apiMonitoring.onCreated(function () {
   // Get reference of template instance
@@ -12,10 +12,11 @@ Template.apiMonitoring.onCreated(function () {
   const apiId = instance.data.api._id;
 
   // Subscribe on Monitoring collection
-  instance.subscribe('monitoring', apiId);
+  instance.subscribe('monitoringSettings', apiId);
 });
 
 Template.apiMonitoring.onRendered(function () {
+  // Show a small popup on clicking the help icon
   $('[data-toggle="popover"]').popover();
 });
 
@@ -25,23 +26,23 @@ Template.apiMonitoring.helpers({
     const apiId = this.api._id;
 
     // Get api monitoring document
-    return Monitoring.findOne({ apiId });
+    return MonitoringSettings.findOne({ apiId });
   },
   monitoringCollection () {
     // Collection for autoform
-    return Monitoring;
+    return MonitoringSettings;
   },
   formType () {
     // Get API ID
     const apiId = this.api._id;
 
     // Look for existing monitoring document for this API
-    const existingSettings = Monitoring.findOne({ apiId });
+    const existingSettings = MonitoringSettings.findOne({ apiId });
 
     if (existingSettings) {
       return 'update';
-    } else {
-      return 'insert';
     }
+
+    return 'insert';
   },
 });

--- a/monitoring/client/monitoring.js
+++ b/monitoring/client/monitoring.js
@@ -1,0 +1,47 @@
+// Meteor package imports
+import { Template } from 'meteor/templating';
+
+// Apinf import
+import { Monitoring } from '/monitoring/collection';
+
+Template.apiMonitoring.onCreated(function () {
+  // Get reference of template instance
+  const instance = this;
+
+  // Get api id
+  const apiId = instance.data.api._id;
+
+  // Subscribe on Monitoring collection
+  instance.subscribe('monitoring', apiId);
+});
+
+Template.apiMonitoring.onRendered(function () {
+  $('[data-toggle="popover"]').popover();
+});
+
+Template.apiMonitoring.helpers({
+  apiMonitoringSettings () {
+    // Get api id
+    const apiId = this.api._id;
+
+    // Get api monitoring document
+    return Monitoring.findOne({ apiId });
+  },
+  monitoringCollection () {
+    // Collection for autoform
+    return Monitoring;
+  },
+  formType () {
+    // Get API ID
+    const apiId = this.api._id;
+
+    // Look for existing monitoring document for this API
+    const existingSettings = Monitoring.findOne({ apiId });
+
+    if (existingSettings) {
+      return 'update';
+    } else {
+      return 'insert';
+    }
+  },
+});

--- a/monitoring/collection/index.js
+++ b/monitoring/collection/index.js
@@ -1,0 +1,3 @@
+const Monitoring = new Mongo.Collection('Monitoring');
+
+export { Monitoring };

--- a/monitoring/collection/index.js
+++ b/monitoring/collection/index.js
@@ -1,3 +1,4 @@
-const Monitoring = new Mongo.Collection('Monitoring');
+const MonitoringSettings = new Mongo.Collection('MonitoringSettings');
+const MonitoringData = new Mongo.Collection('MonitoringData');
 
-export { Monitoring };
+export { MonitoringSettings, MonitoringData };

--- a/monitoring/collection/permissions.js
+++ b/monitoring/collection/permissions.js
@@ -1,0 +1,39 @@
+// APINF import
+import { Monitoring } from './';
+import { Apis } from '/apis/collection';
+
+Monitoring.allow({
+  insert (userId, data) {
+    // Only allow API Managers or Administrators to insert
+
+    // Get API document
+    const api = Apis.findOne(data.apiId);
+
+    // Check if current user can edit API
+    if (api && api.currentUserCanEdit()) {
+      return true;
+    }
+  },
+  update (userId, data) {
+    // Only allow API Managers or Administrators to update
+
+    // Get API document
+    const api = Apis.findOne(data.apiId);
+
+    // Check if current user can edit API
+    if (api && api.currentUserCanEdit()) {
+      return true;
+    }
+  },
+  remove (userId, data) {
+    // Only allow API Managers or Administrators to remove
+
+    // Get API document
+    const api = Apis.findOne(data.apiId);
+
+    // Check if current user can edit API
+    if (api && api.currentUserCanEdit()) {
+      return true;
+    }
+  },
+});

--- a/monitoring/collection/permissions.js
+++ b/monitoring/collection/permissions.js
@@ -1,8 +1,8 @@
 // APINF import
-import { Monitoring } from './';
 import { Apis } from '/apis/collection';
+import { MonitoringSettings, MonitoringData } from './';
 
-Monitoring.allow({
+MonitoringSettings.allow({
   insert (userId, data) {
     // Only allow API Managers or Administrators to insert
 

--- a/monitoring/collection/permissions.js
+++ b/monitoring/collection/permissions.js
@@ -1,6 +1,6 @@
 // APINF import
 import { Apis } from '/apis/collection';
-import { MonitoringSettings, MonitoringData } from './';
+import { MonitoringSettings } from './';
 
 MonitoringSettings.allow({
   insert (userId, data) {
@@ -9,10 +9,8 @@ MonitoringSettings.allow({
     // Get API document
     const api = Apis.findOne(data.apiId);
 
-    // Check if current user can edit API
-    if (api && api.currentUserCanEdit()) {
-      return true;
-    }
+    // Check if current user can insert the monitoring settings and return this value
+    return api && api.currentUserCanEdit();
   },
   update (userId, data) {
     // Only allow API Managers or Administrators to update
@@ -20,10 +18,8 @@ MonitoringSettings.allow({
     // Get API document
     const api = Apis.findOne(data.apiId);
 
-    // Check if current user can edit API
-    if (api && api.currentUserCanEdit()) {
-      return true;
-    }
+    // Check if current user can edit the monitoring settings and return this value
+    return api && api.currentUserCanEdit();
   },
   remove (userId, data) {
     // Only allow API Managers or Administrators to remove
@@ -31,9 +27,7 @@ MonitoringSettings.allow({
     // Get API document
     const api = Apis.findOne(data.apiId);
 
-    // Check if current user can edit API
-    if (api && api.currentUserCanEdit()) {
-      return true;
-    }
+    // Check if current user can delete the monitoring settings and return this value
+    return api && api.currentUserCanEdit();
   },
 });

--- a/monitoring/collection/schema.js
+++ b/monitoring/collection/schema.js
@@ -2,14 +2,18 @@
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 
 // APINF import
-import { Monitoring } from './';
+import { MonitoringSettings, MonitoringData } from './';
 
-Monitoring.schema = new SimpleSchema({
+MonitoringSettings.schema = new SimpleSchema({
   apiId: {
     type: String,
   },
   enabled: {
     type: Boolean,
+    optional: true,
+  },
+  data: {
+    type: String,
     optional: true,
   },
   url: {
@@ -26,25 +30,29 @@ Monitoring.schema = new SimpleSchema({
       }
       return validation;
     },
+  }
+});
+
+MonitoringData.schema = new SimpleSchema({
+  apiId: {
+    type: String,
   },
-  requests: {
+  responses: {
     type: [Object],
     optional: true,
   },
-  'requests.$.date': {
+  'responses.$.date': {
     type: String,
     optional: true,
   },
-  'requests.$.status_code': {
+  'responses.$.server_status_code': {
     type: String,
     optional: true,
-  },
-  'requests.$.apiStatus': {
-    type: String,
-    optional: true,
-  },
+  }
 });
 // Enable translations (i18n)
-Monitoring.schema.i18n('schemas.monitoring');
+MonitoringSettings.schema.i18n('schemas.monitoring');
 
-Monitoring.attachSchema(Monitoring.schema);
+MonitoringSettings.attachSchema(MonitoringSettings.schema);
+MonitoringData.attachSchema(MonitoringData.schema);
+

--- a/monitoring/collection/schema.js
+++ b/monitoring/collection/schema.js
@@ -4,6 +4,7 @@ import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 // APINF import
 import { MonitoringSettings, MonitoringData } from './';
 
+// Describe collection for store data associate with monitoring settings
 MonitoringSettings.schema = new SimpleSchema({
   apiId: {
     type: String,
@@ -30,9 +31,10 @@ MonitoringSettings.schema = new SimpleSchema({
       }
       return validation;
     },
-  }
+  },
 });
 
+// Describe collection for store data form server
 MonitoringData.schema = new SimpleSchema({
   apiId: {
     type: String,

--- a/monitoring/collection/schema.js
+++ b/monitoring/collection/schema.js
@@ -1,0 +1,50 @@
+// Meteor packages import
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+
+// APINF import
+import { Monitoring } from './';
+
+Monitoring.schema = new SimpleSchema({
+  apiId: {
+    type: String,
+  },
+  enabled: {
+    type: Boolean,
+    optional: true,
+  },
+  url: {
+    type: String,
+    regEx: SimpleSchema.RegEx.Url,
+    custom () {
+      const monitoringUrlEnabled = this.field('enabled').value;
+      const monitoringUrl = this.value;
+      let validation;
+
+      // Require editor host if apiDocumentationEditor.enabled is checked
+      if (monitoringUrlEnabled === true && !monitoringUrl) {
+        validation = 'required';
+      }
+      return validation;
+    },
+  },
+  requests: {
+    type: [Object],
+    optional: true,
+  },
+  'requests.$.date': {
+    type: String,
+    optional: true,
+  },
+  'requests.$.status_code': {
+    type: String,
+    optional: true,
+  },
+  'requests.$.apiStatus': {
+    type: String,
+    optional: true,
+  },
+});
+// Enable translations (i18n)
+Monitoring.schema.i18n('schemas.monitoring');
+
+Monitoring.attachSchema(Monitoring.schema);

--- a/monitoring/collection/server/publications.js
+++ b/monitoring/collection/server/publications.js
@@ -2,8 +2,9 @@
 import { Meteor } from 'meteor/meteor';
 
 // APINF import
-import { Monitoring } from '/monitoring/collection';
+import { MonitoringSettings } from '/monitoring/collection';
 
-Meteor.publish('monitoring', function (apiId) {
-  return Monitoring.find({ apiId });
+Meteor.publish('monitoringSettings', function (apiId) {
+  return MonitoringSettings.find({ apiId });
 });
+

--- a/monitoring/collection/server/publications.js
+++ b/monitoring/collection/server/publications.js
@@ -1,0 +1,9 @@
+// Meteor packages import
+import { Meteor } from 'meteor/meteor';
+
+// APINF import
+import { Monitoring } from '/monitoring/collection';
+
+Meteor.publish('monitoring', function (apiId) {
+  return Monitoring.find({ apiId });
+});

--- a/monitoring/server/cron.js
+++ b/monitoring/server/cron.js
@@ -1,0 +1,74 @@
+// Meteor package imports
+import { Meteor } from 'meteor/meteor';
+import { SyncedCron } from 'meteor/percolate:synced-cron';
+
+// APINF import
+import { Monitoring } from '/monitoring/collection';
+import { Apis } from '/apis/collection';
+
+// NPM packages import
+import _ from 'lodash';
+
+Meteor.methods({
+  startCron (apiId, url) {
+    // Create unique name for Cron job
+    const uniqueName = 'Monitoring: ' + apiId;
+
+    // Set time of the monitoring call
+    const cronTime = 'every 1 hour';
+
+    // Update api status to 'Loading...'
+    Apis.update(apiId, { $set: { status_code: 0 } });
+
+
+    // Create cron working
+    SyncedCron.add({
+      name: uniqueName,
+      schedule (parser) {
+        // parser is a later.parse object
+        return parser.text(cronTime);
+      },
+      job () {
+        // Call HTTP request
+        Meteor.http.get(url, {}, (error, result) => {
+          // Set status code
+          const serverStatusCode = result ? result.statusCode : 500;
+
+          // Create a monitoring data
+          const monitoringData = {
+            date: new Date(),
+            status_code: serverStatusCode,
+          };
+
+          // Update an api status
+          Apis.update({ _id: apiId }, { $set: { status_code: serverStatusCode } });
+
+          // Add the monitoring data in Collection
+          Monitoring.update({ apiId }, { $push: { requests: monitoringData } });
+        });
+      },
+    });
+  },
+  stopCron (apiId) {
+    // Create unique name for Cron job
+    const uniqueName = 'Monitoring: ' + apiId;
+
+    // Stop Cron job
+    SyncedCron.remove(uniqueName);
+
+    // Update an api status
+    Apis.update({ _id: apiId }, { $set: { status_code: -1 } });
+  },
+  restartCron () {
+    // Get all apis which are added in monitoring
+    const monitoring = Monitoring.find().fetch();
+
+    _.forEach(monitoring, (data) => {
+      // If enabled is true then switch the monitoring
+      if (data.enabled) {
+        Meteor.call('startCron', data.apiId, data.url);
+      }
+    });
+  },
+});
+


### PR DESCRIPTION
Closes #1512 
Closes #1515

## Changes
- Create a new collection Monitoring: schema, permissions, publications
- Linked the Monitoring and APIs collections
- Create a new template, realize the layout, add this on a new section on API Settings tab
- Create the new server methods for manipulations with Cron
- When meteor server is restarted, cron is restarted too
- Update status indicator icon:
  * nothing icon: monitoring is disable
  * blue:  status code is 1xx
  * green: status code are 2xx or 3xx
  * orange: status code is 4xx
  * red: status code is 5xx
  * grey: monitoring is enable but status code is unknown
- Change APIs collection schema: add field status_code for saving server status code
-  Add auto-value field  on template 'Add api' with status_code = -1 by default
- Upgrade status.js: checking on status and returning className and statusText have own function

## After reviewing
- Remove methods field
- Add comment
- Change default status code fom 500 to 404
- Moving the status check function into its own Meteor method
- Add a single call to the Monitoring method in the onSuccess callback
- Rename field in apis collection
- Refactoring of monitoring collection
- Do an icon indicator reactive
- Fix markup after rename class for indicator