### PR TITLE
Feature/remove manage apis link

### DIFF
--- a/core/client/navbar/navbar.html
+++ b/core/client/navbar/navbar.html
@@ -33,26 +33,11 @@
               </li>
             {{/ if }}
             {{# if userCanAddApi }}
-              <li class="dropdown">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
-                  {{_ "masterLayout_sidebar_APIBackends" }}
-                  <i class="fa fa-chevron-down"></i>
-                </a>
-                <ul class="dropdown-menu">
-                  <li>
-                    <a href="{{ pathFor route='addApi' }}">
-                      {{_ "masterLayout_sidebar_AddAPIBackend" }}
-                    </a>
-                  </li>
-                  {{# if isInRole 'manager' }}
-                  <li>
-                    <a href="{{pathFor route='manageApiBackends' }}">
-                      {{_ "masterLayout_sidebar_ManageAPIBackends" }}
-                    </a>
-                  </li>
-                  {{/ if }}
-                </ul>
-              </li>
+            <li>
+              <a href="{{ pathFor route='addApi' }}">
+                {{_ "masterLayout_sidebar_AddAPIBackend" }}
+              </a>
+            </li>
             {{/ if }}
           {{/ if }}
           <li class="{{isActiveRoute 'catalogue' }}">

--- a/core/client/navbar/navbar.html
+++ b/core/client/navbar/navbar.html
@@ -24,7 +24,7 @@
         <ul class="nav navbar-nav navbar-left">
           {{# if currentUser }}
             {{# if proxyIsDefined }}
-              <li class="{{isActiveRoute 'dashboard' }}">
+              <li class="{{ isActiveRoute 'dashboard' }}">
                 <a href="/dashboard">
                   <span>
                     {{_ "Dashboard" }}
@@ -33,22 +33,22 @@
               </li>
             {{/ if }}
             {{# if userCanAddApi }}
-            <li>
+            <li class="{{ isActiveRoute 'addApi' }}">
               <a href="{{ pathFor route='addApi' }}">
                 {{_ "masterLayout_sidebar_AddAPIBackend" }}
               </a>
             </li>
             {{/ if }}
           {{/ if }}
-          <li class="{{isActiveRoute 'catalogue' }}">
+          <li class="{{ isActiveRoute 'catalogue' }}">
             <a href="/catalogue">
               {{_ "masterLayout_sidebar_Catalogue" }}
             </a>
           </li>
           {{# if currentUser }}
             {{# if isInRole 'admin' }}
-              <li class="{{isActiveRoute 'accountsAdmin' }}">
-                <a href="{{pathFor route='accountsAdmin' }}">
+              <li class="{{ isActiveRoute 'accountsAdmin' }}">
+                <a href="{{ pathFor route='accountsAdmin' }}">
                   <span>
                     {{_ "masterLayout_sidebar_Users" }}
                   </span>

--- a/core/client/navbar/navbar.html
+++ b/core/client/navbar/navbar.html
@@ -26,32 +26,33 @@
             {{# if proxyIsDefined }}
               <li class="{{ isActiveRoute 'dashboard' }}">
                 <a href="/dashboard">
-                  <span>
-                    {{_ "Dashboard" }}
-                  </span>
+                  <i class="fa fa-bar-chart" aria-hidden="true"></i>
+                  {{_ "Dashboard" }}
                 </a>
               </li>
             {{/ if }}
-            {{# if userCanAddApi }}
-            <li class="{{ isActiveRoute 'addApi' }}">
-              <a href="{{ pathFor route='addApi' }}">
-                {{_ "masterLayout_sidebar_AddAPIBackend" }}
-              </a>
-            </li>
-            {{/ if }}
           {{/ if }}
           <li class="{{ isActiveRoute 'catalogue' }}">
-            <a href="/catalogue">
+            <a href="{{ pathFor route='catalogue' }}">
+              <i class="fa fa-book" aria-hidden="true"></i>
               {{_ "masterLayout_sidebar_Catalogue" }}
             </a>
           </li>
           {{# if currentUser }}
+            {{# if userCanAddApi }}
+            <li class="{{ isActiveRoute 'addApi' }}">
+              <a href="{{ pathFor route='addApi' }}">
+                <i class="fa fa-plus" aria-hidden="true"></i>
+
+                {{_ "masterLayout_sidebar_AddAPIBackend" }}
+              </a>
+            </li>
+            {{/ if }}
             {{# if isInRole 'admin' }}
               <li class="{{ isActiveRoute 'accountsAdmin' }}">
                 <a href="{{ pathFor route='accountsAdmin' }}">
-                  <span>
-                    {{_ "masterLayout_sidebar_Users" }}
-                  </span>
+                  <i class="fa fa-users" aria-hidden="true"></i>
+                  {{_ "masterLayout_sidebar_Users" }}
                 </a>
               </li>
             {{/ if }}
@@ -63,11 +64,13 @@
           {{ else }}
           <li>
             <a class="close-navbar" href="/sign-up">
+              <i class="fa fa-user-plus" aria-hidden="true"></i>
               {{_ "signup" }}
             </a>
           </li>
           <li>
             <a class="close-navbar" href="/sign-in">
+              <i class="fa fa-sign-in" aria-hidden="true"></i>
               {{_ "login" }}
             </a>
           </li>

--- a/core/client/userMenu.html
+++ b/core/client/userMenu.html
@@ -7,7 +7,9 @@
       role="button"
       aria-haspopup="true"
       aria-expanded="false">
-        {{ user.username }}&nbsp;
+      <i class="fa fa-user" aria-hidden="true"></i>
+        {{ user.username }}
+        &nbsp;
         <i class="fa fa-chevron-down"></i>
     </a>
     <ul class="dropdown-menu">

--- a/core/lib/i18n/en.i18n.json
+++ b/core/lib/i18n/en.i18n.json
@@ -310,7 +310,6 @@
   "masterLayout_sidebar_APIBackends": "API Backends",
   "masterLayout_sidebar_AddAPIBackend": "Add API",
   "masterLayout_sidebar_Catalogue": "Catalog",
-  "masterLayout_sidebar_ManageAPIBackends": "Manage APIs",
   "masterLayout_sidebar_Users": "Users",
   "navbar_aboutButton_text": "About",
   "notAuthorized_Message": "You are not authorized to access this page.",


### PR DESCRIPTION
Closes #1743 
Closes #1755 

# Changes
- remove 'Manage APIs' link from navbar
- move 'Add API' to top level link (no dropdown)