### PR TITLE
Migrate on jshimko/meteor-launchpad base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Based on "MeteorD - Docker Runtime for Meteor Apps for Production Deployments"
-FROM apinf/meteord:onbuild
+# A base Docker image for Meteor applications. https://hub.docker.com/r/jshimko/meteor-launchpad/
+FROM jshimko/meteor-launchpad:latest
 
 MAINTAINER apinf <info@apinf.io>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ services:
       - 'docker/apinf/env'
     environment:
       - MONGO_URL=mongodb://mongo/apinf_db
-    ports:
-      - "3000:80"
     depends_on:
       - mongo
       - ssl
@@ -43,7 +41,7 @@ services:
     env_file:
       - 'docker/ssl/env'
     environment:
-      - UPSTREAM=apinf:80
+      - UPSTREAM=apinf:3000
     ports:
       - "443:443"
       - "80:80"


### PR DESCRIPTION
- Migrate on jshimko/meteor-launchpad base docker image (more secure, by default install right meteor version, less image layers).
- Changed port number on proxy (nginx with LetsEncrypt).
- Dropped extra port expose.