### PR TITLE
Feature/contact form smtp

### DIFF
--- a/home/client/contact/contact.html
+++ b/home/client/contact/contact.html
@@ -3,7 +3,7 @@
     schema=contactFormSchema
     id="contactForm"
     type="method"
-    meteormethod="sendEmail" }}
+    meteormethod="sendContactFormEmail" }}
   <fieldset>
     {{> afQuickField name="name" }}
     {{> afQuickField name="email" }}

--- a/home/client/contact/contact.js
+++ b/home/client/contact/contact.js
@@ -1,5 +1,5 @@
 import { Template } from 'meteor/templating';
-import { ContactFormSchema } from '../../contactFormSchema';
+import ContactFormSchema from '../../contactFormSchema';
 
 Template.contactForm.helpers({
   contactFormSchema () {

--- a/home/contactFormSchema.js
+++ b/home/contactFormSchema.js
@@ -1,4 +1,4 @@
-const ContactFormSchema = new SimpleSchema({
+export default new SimpleSchema({
   name: {
     type: String,
     label: TAPi18n.__('contactForm_name_label'),
@@ -28,5 +28,3 @@ const ContactFormSchema = new SimpleSchema({
     },
   },
 });
-
-export { ContactFormSchema };

--- a/home/contactFormSchema.js
+++ b/home/contactFormSchema.js
@@ -1,3 +1,6 @@
+import { SimpleSchema } from 'meteor/aldeed:simple-schema';
+import { TAPi18n } from 'meteor/tap:i18n';
+
 export default new SimpleSchema({
   name: {
     type: String,

--- a/home/server/methods.js
+++ b/home/server/methods.js
@@ -1,6 +1,6 @@
 import { Meteor } from 'meteor/meteor';
 import { Settings } from '/settings/collection';
-import { ContactFormSchema } from '../contactFormSchema';
+import ContactFormSchema from '../contactFormSchema';
 
 Meteor.methods({
   sendEmail (doc) {

--- a/home/server/methods.js
+++ b/home/server/methods.js
@@ -5,7 +5,7 @@ import { Settings } from '/settings/collection';
 import ContactFormSchema from '../contactFormSchema';
 
 Meteor.methods({
-  sendEmail (doc) {
+  sendContactFormEmail (doc) {
     // Important server-side check for security and data integrity
     check(doc, ContactFormSchema);
 

--- a/home/server/methods.js
+++ b/home/server/methods.js
@@ -1,3 +1,5 @@
+import { check } from 'meteor/check';
+import { Email } from 'meteor/email';
 import { Meteor } from 'meteor/meteor';
 import { Settings } from '/settings/collection';
 import ContactFormSchema from '../contactFormSchema';
@@ -8,21 +10,26 @@ Meteor.methods({
     check(doc, ContactFormSchema);
 
     // Build the e-mail text
-    const text = 'Name: ' + doc.name + '\n\n'
-    + 'Email: ' + doc.email + '\n\n\n\n'
-    + doc.message;
+    const text = `Name: ${doc.name}
+
+Email: ${doc.email}
+
+${doc.message}`;
 
     this.unblock();
 
-    // Get email settings
-    const mailSettings = Settings.findOne().mail;
+    // Get settings
+    const settings = Settings.findOne();
 
-    // Send the e-mail
-    Email.send({
-      to: mailSettings.toEmail,
-      from: mailSettings.fromEmail,
-      subject: 'Apinf Contact Form - Message From ' + doc.name,
-      text,
-    });
+    // Check if email settings are configured
+    if (settings.mail && settings.mail.enabled) {
+      // Send the e-mail
+      Email.send({
+        to: settings.mail.toEmail,
+        from: settings.mail.fromEmail,
+        subject: `Contact Form - message from ${doc.name}`,
+        text,
+      });
+    }
   },
 });

--- a/home/server/methods.js
+++ b/home/server/methods.js
@@ -20,7 +20,7 @@ Meteor.methods({
     // Send the e-mail
     Email.send({
       to: mailSettings.toEmail,
-      from: doc.email,
+      from: mailSettings.fromEmail,
       subject: 'Apinf Contact Form - Message From ' + doc.name,
       text,
     });


### PR DESCRIPTION
Closes #1842 

# Changes
- use mail settings `fromEmail` when sending mail
- refactor `sendContactFormEmail` method
  - lint
  - imports
  - template strings
  - explicit method name
- use exports default for contact form schema