### PR TITLE
Remove Horizontal scrollbar from APINF landing page

### DIFF
--- a/home/client/body/homeBody.html
+++ b/home/client/body/homeBody.html
@@ -152,7 +152,7 @@
           </p>
           {{/ unless }}
         </div>
-        <div class="col-lg-4 col-lg-push-1 col-sm-6">
+        <div class="col-lg-4 col-sm-6">
           <i class="fa fa-tachometer"></i>
         </div>
       </div>
@@ -206,7 +206,7 @@
             </a>
           </p>
         </div>
-        <div class="col-lg-4 col-lg-push-1 col-sm-6">
+        <div class="col-lg-4 col-sm-6">
           <img
           class="img-responsive"
           src="img/opensource.png"

--- a/home/client/body/homeBody.less
+++ b/home/client/body/homeBody.less
@@ -116,6 +116,7 @@ hr.primary {
 
   .fa {
     text-shadow: 4px 3px 0px #b3e5fc, 9px 8px 0px rgba(0, 0, 0, 0.15);
+    float: right;
   }
 }
 
@@ -133,6 +134,7 @@ hr.primary {
   img {
     -webkit-filter: drop-shadow(9px 8px 0px rgba(0, 0, 0, 0.15));
     filter: drop-shadow(9px 8px 0px rgba(0, 0, 0, 0.15));
+    float: right;
   }
 }
 


### PR DESCRIPTION
Cause of horizontal scroll are the images in the "getting started" and "completely open source" sections. The bootstrap class 'col-lg-push-1' is pushing the that div outside of the .container width.

Removed the 'col-lg-push-1' from the html and added float:right to the images.

Closes #1867 