### PR TITLE
Replaced backend_prefix regex with apiBasePathLooseRegEx

### DIFF
--- a/proxy_backends/client/form/autoform.js
+++ b/proxy_backends/client/form/autoform.js
@@ -29,7 +29,7 @@ AutoForm.hooks({
           const requiredUrlMatches = apiUmbrella.url_matches &&
             apiUmbrella.url_matches[0] &&
             apiUmbrella.url_matches[0].frontend_prefix &&
-            apiUmbrella.url_matches[0].backend_prefix;
+            apiUmbrella.url_matches[0].backend_loose_prefix;
 
           const requiredServers = apiUmbrella.servers && apiUmbrella.servers[0] &&
             apiUmbrella.servers[0].host &&
@@ -112,7 +112,7 @@ AutoForm.hooks({
           const requiredUrlMatches = currentProxyBackend['apiUmbrella.url_matches'] &&
             currentProxyBackend['apiUmbrella.url_matches'][0] &&
             currentProxyBackend['apiUmbrella.url_matches'][0].frontend_prefix &&
-            currentProxyBackend['apiUmbrella.url_matches'][0].backend_prefix;
+            currentProxyBackend['apiUmbrella.url_matches'][0].backend_loose_prefix;
 
           const requiredServers = currentProxyBackend['apiUmbrella.servers'] &&
             currentProxyBackend['apiUmbrella.servers'][0] &&

--- a/proxy_backends/client/form/form.html
+++ b/proxy_backends/client/form/form.html
@@ -62,7 +62,7 @@
     <div class="row">
       <div class="form-group col-md-9">
         <label for="api-base-path-field">
-          {{ afFieldLabelText name='apiUmbrella.url_matches.0.backend_prefix' }}
+          {{ afFieldLabelText name='apiUmbrella.url_matches.0.backend_loose_prefix' }}
         </label>
 
         <div class="input-group">
@@ -72,7 +72,7 @@
           </span>
 
           {{> afFieldInput
-            name="apiUmbrella.url_matches.0.backend_prefix"
+            name="apiUmbrella.url_matches.0.backend_loose_prefix"
             class="form-control"
             aria-describedby="api-url"
             id="api-base-path-field"
@@ -80,9 +80,9 @@
         </div>
 
         <!-- validation messages -->
-        {{# if afFieldIsInvalid name='apiUmbrella.url_matches.0.backend_prefix' }}
+        {{# if afFieldIsInvalid name='apiUmbrella.url_matches.0.backend_loose_prefix' }}
           <p class="text-danger">
-            {{{ afFieldMessage name='apiUmbrella.url_matches.0.backend_prefix' }}}
+            {{{ afFieldMessage name='apiUmbrella.url_matches.0.backend_loose_prefix' }}}
           </p>
         {{/ if }}
 

--- a/proxy_backends/collection/apiUmbrellaSchema.js
+++ b/proxy_backends/collection/apiUmbrellaSchema.js
@@ -1,6 +1,6 @@
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 // Utility import
-import { proxyBasePathRegEx, apiBasePathRegEx } from './regex';
+import { proxyBasePathRegEx, apiBasePathRegEx, apiBasePathLooseRegEx } from './regex';
 
 const RateLimitSchema = new SimpleSchema({
   duration: {
@@ -102,6 +102,12 @@ const ApiUmbrellaSchema = new SimpleSchema({
     optional: true,
     label: 'API base path',
     regEx: apiBasePathRegEx,
+  },
+  'url_matches.$.backend_loose_prefix': {
+    type: String,
+    optional: true,
+    label: 'API base path',
+    regEx: apiBasePathLooseRegEx,
   },
   servers: {
     type: [Object],

--- a/proxy_backends/collection/regex.js
+++ b/proxy_backends/collection/regex.js
@@ -1,3 +1,5 @@
 export const proxyBasePathRegEx = new RegExp(/^\/[a-z0-9A-Z_\-\/]+\/$/);
 
 export const apiBasePathRegEx = new RegExp(/^\/[a-z0-9A-Z_\-\/]*$/);
+
+export const apiBasePathLooseRegEx = new RegExp(/^\/[a-z0-9A-Z-?=.&%()_\-\/]*$/);


### PR DESCRIPTION
Closes #1965 


Problem:
To make calling of prefix simple even with queryParams https://apinf.io/myPrefix 
-> https://html-to-json.herokuapp.com/jquery?site=https://www.tsr.fi/uudet-hanketiedotteet&selector=find(%27.list-items%20li%27)&forceText=true

And not like
https://apinf.io/myPrefix/?site=https://www.tsr.fi/uudet-hanketiedotteet&selector=find(%27.list-items%20li%27)&forceText=true

To make this kind of proxy work (which is proxy in itself, see https://github.com/santeriv/pulljson)

URL:
https://html-to-json.herokuapp.com
apiBasePath:
/jquery?site=https://www.tsr.fi/uudet-hanketiedotteet&selector=find(%27.list-items%20li%27)&forceText=true

Other option would have been to make work with just URL and no prefix:
URL:
https://html-to-json.herokuapp.com/jquery?site=https://www.tsr.fi/uudet-hanketiedotteet&selector=find(%27.list-items%20li%27)&forceText=true

But it seems not to work either. Tried with nightly build 2.12.2016 (https://nightly.apinf.io/).

* Not tested, no docker capable environment at hand, used just browser, regex was tested with regexpal 
* Thought also making a loose/strict checkbox but I wanted to await your reaction also, because first idea was to just replace existing regex. Tried to learn something about meteor app development also.
* Motivation: I do this just for fun and not for commercial purposes
*  Found this tool from twitter post : https://twitter.com/kyyberi/status/804708650925363200?lang=fi