### PR TITLE
Bugfix/dashboard back arrow

### DIFF
--- a/dashboard/client/dashboard.js
+++ b/dashboard/client/dashboard.js
@@ -47,20 +47,23 @@ Template.dashboard.onCreated(function () {
         granularity,
       };
 
-      // Check of existing needed proxy data
-      Meteor.call('getProxyData', backendParameter, (error, result) => {
-        // if it was not error
-        if (!error) {
-          // Provide proxy data to elastic search
-          instance.getChartData(result, filterParameters)
-            .then((chartData) => {
-              // Update reactive variable
-              instance.chartData.set(chartData);
-            })
-            // eslint-disable-next-line no-console
-            .catch(err => { return console.error(err); });
-        }
-      });
+      // Make sure backend id exists
+      if (backendParameter) {
+        // Check of existing needed proxy data
+        Meteor.call('getProxyData', backendParameter, (error, result) => {
+          // if it was not error
+          if (!error) {
+            // Provide proxy data to elastic search
+            instance.getChartData(result, filterParameters)
+              .then((chartData) => {
+                // Update reactive variable
+                instance.chartData.set(chartData);
+              })
+              // eslint-disable-next-line no-console
+              .catch(err => { return console.error(err); });
+          }
+        });
+      }
     }
   });
 });

--- a/dashboard/client/dashboard.js
+++ b/dashboard/client/dashboard.js
@@ -82,8 +82,11 @@ Template.dashboard.helpers({
     const backendParameter = FlowRouter.getQueryParam('backend');
     // If query param doesn't exist and proxy backend list is ready
     if (!backendParameter && proxyBackends[0]) {
-      // Set the default value as first item of backend list
-      FlowRouter.setQueryParams({ backend: proxyBackends[0]._id });
+      // Modifies the current history entry instead of creating a new one
+      FlowRouter.withReplaceState(() => {
+        // Set the default value as first item of backend list
+        FlowRouter.setQueryParams({ backend: proxyBackends[0]._id });
+      });
     }
 
     return proxyBackends;

--- a/dashboard/client/filtering/api_select/api_select.js
+++ b/dashboard/client/filtering/api_select/api_select.js
@@ -25,14 +25,16 @@ Template.apiSelectPicker.onRendered(function () {
   // Get reference to template instance
   const instance = this;
 
-  // Get Proxy Backend ID parameter from URL,
-  const proxyBackendId = FlowRouter.getQueryParam('backend');
+  instance.autorun(() => {
+    // Get Proxy Backend ID parameter from URL,
+    const proxyBackendId = FlowRouter.getQueryParam('backend');
 
-  // Change value of proxy backend select, if URL parameter is present
-  if (proxyBackendId) {
-    // Update the select menu to match the Proxy Backend ID
-    instance.$('#proxy-backend-select').val(proxyBackendId);
-  }
+    // Change value of proxy backend select, if URL parameter is present
+    if (proxyBackendId) {
+      // Update the select menu to match the Proxy Backend ID
+      instance.$('#proxy-backend-select').val(proxyBackendId);
+    }
+  });
 });
 
 Template.apiSelectPicker.events({

--- a/dashboard/client/filtering/api_select/api_select.js
+++ b/dashboard/client/filtering/api_select/api_select.js
@@ -39,7 +39,10 @@ Template.apiSelectPicker.onRendered(function () {
 
 Template.apiSelectPicker.events({
   'change #proxy-backend-select': function (event) {
-    // Update selected backend URL parameter
-    FlowRouter.setQueryParams({ backend: event.target.value });
+    // Modifies the current history entry instead of creating a new one
+    FlowRouter.withReplaceState(() => {
+      // Update selected backend URL parameter
+      FlowRouter.setQueryParams({ backend: event.target.value });
+    });
   },
 });

--- a/dashboard/client/filtering/datepicker/datepicker.js
+++ b/dashboard/client/filtering/datepicker/datepicker.js
@@ -13,8 +13,11 @@ Template.timeFrameSelectPicker.onRendered(() => {
   // Save chosen date to URL parameter
   // in order to share dashboard state
   .on('changeDate', (event) => {
-    // Set fromDate URL parameter to ISO YYYY-mm-dd
-    FlowRouter.setQueryParams({ fromDate: event.format('yyyy-mm-dd') });
+    // Modifies the current history entry instead of creating a new one
+    FlowRouter.withReplaceState(() => {
+      // Set fromDate URL parameter to ISO YYYY-mm-dd
+      FlowRouter.setQueryParams({ fromDate: event.format('yyyy-mm-dd') });
+    });
   });
 
   // Check URL parameters for 'from date' for analytics timeframe
@@ -29,9 +32,12 @@ Template.timeFrameSelectPicker.onRendered(() => {
   $('#analytics-timeframe-end').datepicker()
   // Save chosen date to URL parameter
   .on('changeDate', (event) => {
-    // Set fromDate URL parameter to ISO YYYY-mm-dd
-    // in order to share dashboard state
-    FlowRouter.setQueryParams({ toDate: event.format('yyyy-mm-dd') });
+    // Modifies the current history entry instead of creating a new one
+    FlowRouter.withReplaceState(() => {
+      // Set fromDate URL parameter to ISO YYYY-mm-dd
+      // in order to share dashboard state
+      FlowRouter.setQueryParams({ toDate: event.format('yyyy-mm-dd') });
+    });
   });
 
   // Check URL parameters for 'from date' for analytics timeframe

--- a/dashboard/client/filtering/granularity/granularity.html
+++ b/dashboard/client/filtering/granularity/granularity.html
@@ -1,7 +1,7 @@
 <template name="granularity">
   <div class="btn-group" data-toggle="buttons" id="date-granularity-selector">
-    <label class="btn btn-default" for="month-input" id="month-granularity">
-      <input type="radio" name="granularity" value="month" checked>
+    <label class="btn btn-default active" for="month-input" id="month-granularity">
+      <input type="radio" name="granularity" value="month">
       {{_ "granularity_month" }}
     </label>
 

--- a/dashboard/client/filtering/granularity/granularity.js
+++ b/dashboard/client/filtering/granularity/granularity.js
@@ -16,7 +16,10 @@ Template.granularity.onRendered(function () {
 
 Template.granularity.events({
   'change #date-granularity-selector': function (event) {
-    // Set granularity value to URL parameter
-    FlowRouter.setQueryParams({ granularity: event.target.value });
+    // Modifies the current history entry instead of creating a new one
+    FlowRouter.withReplaceState(() => {
+      // Set granularity value to URL parameter
+      FlowRouter.setQueryParams({ granularity: event.target.value });
+    });
   },
 });

--- a/dashboard/client/filtering/granularity/granularity.js
+++ b/dashboard/client/filtering/granularity/granularity.js
@@ -5,19 +5,13 @@ Template.granularity.onRendered(function () {
   // Get reference to template instance
   const instance = this;
 
-// Check URL parameters for granularity
-  const granularityParameter = FlowRouter.getQueryParam('granularity');
+  instance.autorun(() => {
+    // Get granularity parameters
+    const granularityParameter = FlowRouter.getQueryParam('granularity');
 
-  if (granularityParameter) {
     // Set the granularity UI state from URL parameter
     instance.$(`#${granularityParameter}-granularity`).button('toggle');
-  } else {
-    // Get granularity from template
-    const granularity = instance.$('[name=granularity]:checked').val();
-
-    // Set granularity URL parameter from template value
-    FlowRouter.setQueryParams({ granularity });
-  }
+  });
 });
 
 Template.granularity.events({

--- a/dashboard/client/lib/routes.js
+++ b/dashboard/client/lib/routes.js
@@ -10,6 +10,21 @@ signedIn.route('/dashboard', {
       // Set query parameter if it doesn't exist
       context.queryParams.granularity = 'month';
     }
+
+    // Initialize the query parameters which can be conculated in code
+    // Do it to saving url consistent for the browser history
+    if (!context.queryParams.backend) {
+      // Initialize backend parameter if it doesn't specify
+      context.queryParams.backend = null;
+    }
+    if (!context.queryParams.fromDate) {
+      // Initialize fromDate parameter if it doesn't specify
+      context.queryParams.fromDate = null;
+    }
+    if (!context.queryParams.toDate) {
+      // Initialize toDate parameter if it doesn't specify
+      context.queryParams.toDate = null;
+    }
   }],
   name: 'dashboard',
   action () {

--- a/dashboard/client/lib/routes.js
+++ b/dashboard/client/lib/routes.js
@@ -4,6 +4,13 @@ import signedIn from '/core/client/lib/router';
 
 // Add route to signedIn group, requires user to sign in
 signedIn.route('/dashboard', {
+  // Get granularity parameter for Dashboard page on Enter
+  triggersEnter: [function (context) {
+    if (!context.queryParams.granularity) {
+      // Set query parameter if it doesn't exist
+      context.queryParams.granularity = 'month';
+    }
+  }],
   name: 'dashboard',
   action () {
     BlazeLayout.render('masterLayout', { main: 'dashboard' });


### PR DESCRIPTION
Closes #2044 

## Solution
1. Using `FlowRouter.withReplaceState()` to modify the current history entry instead of creating a new one. [Link to Doc](https://github.com/kadirahq/flow-router#flowrouterwithreplacestatefn)
2. Initialize the query parameter in `triggersEnter` function to saving URL consistent. Because all query parameters excluding `granularity` are calculated in code. 
    1. The next URL are the same for the browser history:
      - nightly.apinf.io/dashboard?backend=jwufbT5kXeDcP7mdP&_granularity=month_
      - nightly.apinf.io/dashboard?backend=jwufbT5kXeDcP7mdP&_granularity=week_
    2. The next URL are the different for the browser history
      - nightly.apinf.io/dashboard?_backend=jwufbT5kXeDcP7mdP_&granularity=month
      - nightly.apinf.io/dashboard?_backend=MtejerXbEP92L5CJr_&granularity=month