### PR TITLE
Bugfix/deleting api

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@
     "no-underscore-dangle": [
       2,
       {
-        "allow": ["_id", "__"]
+        "allow": ["_id", "__", "_index", "_type"]
       }
     ],
     "no-negated-condition": [

--- a/apis/server/methods/delete.js
+++ b/apis/server/methods/delete.js
@@ -47,6 +47,7 @@ Meteor.methods({
     // Check if API has proxyBackend
     if (proxyBackend) {
       // Delete analytics information about calls
+      // TODO: How catch the case when deleting was unsuccessful?
       Meteor.call('deleteAnalyticsInformation', proxyBackend._id);
       // Delete proxyBackend
       Meteor.call('deleteProxyBackend', proxyBackend);

--- a/apis/server/methods/delete.js
+++ b/apis/server/methods/delete.js
@@ -46,6 +46,8 @@ Meteor.methods({
 
     // Check if API has proxyBackend
     if (proxyBackend) {
+      // Delete analytics information about calls
+      Meteor.call('deleteAnalyticsInformation', proxyBackend._id);
       // Delete proxyBackend
       Meteor.call('deleteProxyBackend', proxyBackend);
     }

--- a/elasticsearch/server/methods.js
+++ b/elasticsearch/server/methods.js
@@ -133,7 +133,6 @@ Meteor.methods({
                   {
                     wildcard: {
                       request_path: {
-                        // Add '*' to partially match the url
                         value: `${proxyData.frontendPrefix}`,
                       },
                     },

--- a/elasticsearch/server/methods.js
+++ b/elasticsearch/server/methods.js
@@ -1,6 +1,7 @@
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import ElasticSearch from 'elasticsearch';
+import _ from 'lodash';
 
 Meteor.methods({
   getElasticSearchData (proxyData, filterParameters) {

--- a/elasticsearch/server/methods.js
+++ b/elasticsearch/server/methods.js
@@ -151,7 +151,7 @@ Meteor.methods({
     // Search related documents in ElasticSearch storage
     const searchResult = esClient.search(params);
 
-    // Return the Promise result
+    // Work with the Promise result
     searchResult
       .then(response => {
         // Get the hits data if searching was success


### PR DESCRIPTION
Closes #2032 

The main idea is to search related documents in ElasticSearch and delete found documents using the required fields as `_index, _id, _type`. There can be a lot of found documents then I use `bulk` function which can perform many operations at one time. 
Links:
[Delete document](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference-2-4.html#api-delete-2-4)
[Bulk](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference-2-4.html#api-bulk-2-4)

Now I find the documents via `frontend_prefix` that it isn't safe but only available method right now. And I faced with the really long API deleting.
