### PR TITLE
Added escaping characters $.?*+() in proxyBasePathRegEx and apiBasePathRegEx

### DIFF
--- a/proxy_backends/collection/regex.js
+++ b/proxy_backends/collection/regex.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line no-useless-escape
 export const proxyBasePathRegEx = new RegExp(/^\/[\w\-/\.:\?#@!\$&\*\+,;=\'\(\)]+\/$/);
-
+// eslint-disable-next-line no-useless-escape
 export const apiBasePathRegEx = new RegExp(/^\/[\w\-/\.:\?#@!\$&\*\+,;=\'\(\)]*$/);

--- a/proxy_backends/collection/regex.js
+++ b/proxy_backends/collection/regex.js
@@ -1,3 +1,3 @@
-export const proxyBasePathRegEx = new RegExp(/^\/[\w\-/\.:\?#@!\$&\*\+,;='\(\)]+\/$/);
+export const proxyBasePathRegEx = new RegExp(/^\/[\w\-/\.:\?#@!\$&\*\+,;=\'\(\)]+\/$/);
 
-export const apiBasePathRegEx = new RegExp(/^\/[\w\-/\.:\?#@!\$&\*\+,;='\(\)]*$/);
+export const apiBasePathRegEx = new RegExp(/^\/[\w\-/\.:\?#@!\$&\*\+,;=\'\(\)]*$/);

--- a/proxy_backends/collection/regex.js
+++ b/proxy_backends/collection/regex.js
@@ -1,3 +1,3 @@
-export const proxyBasePathRegEx = new RegExp(/^\/[\w\-/.:?#@!$&*+,;='()]+\/$/);
+export const proxyBasePathRegEx = new RegExp(/^\/[\w\-/\.:\?#@!\$&\*\+,;='\(\)]+\/$/);
 
-export const apiBasePathRegEx = new RegExp(/^\/[\w\-/.:?#@!$&*+,;='()]*$/);
+export const apiBasePathRegEx = new RegExp(/^\/[\w\-/\.:\?#@!\$&\*\+,;='\(\)]*$/);


### PR DESCRIPTION
Added escape for characters in proxyBasePathRegEx and apiBasePathRegEx
$.?*+'() 

This is additional correction to PR 2247.