### PR TITLE
Pages via URL

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@
     "no-underscore-dangle": [
       2,
       {
-        "allow": ["_id", "__"]
+        "allow": ["_id", "__", "_initialized"]
       }
     ],
     "no-negated-condition": [

--- a/core/client/lib/router.js
+++ b/core/client/lib/router.js
@@ -10,7 +10,7 @@ import { Roles } from 'meteor/alanning:roles';
 Tracker.autorun(() => {
   // The Roles package actually depends on a subscription.
   // If the subscription is not ready the Roles.userIsInRole method will always return false.
-  // That is used for checking of is user is admin
+  // That is used for checking of does user have the admin role
 
   // Make sure the roles subscription is ready & FlowRouter hasn't initialized already
   if (Roles.subscription.ready() && !FlowRouter._initialized) {

--- a/core/client/lib/router.js
+++ b/core/client/lib/router.js
@@ -16,29 +16,6 @@ const signedIn = FlowRouter.group({
   }],
 });
 
-const requireAdminRole = function () {
-  if (Meteor.user()) {
-    // Get user ID
-    const userId = Meteor.user()._id;
-
-    const userIsAdmin = Roles.userIsInRole(userId, 'admin');
-
-    if (!userIsAdmin) {
-      // User is not authorized to access route
-      FlowRouter.go('notAuthorized');
-    }
-  } else {
-    FlowRouter.go('signIn');
-  }
-};
-
-// Define 404 route
-FlowRouter.notFound = {
-  action () {
-    BlazeLayout.render('masterLayout', { main: 'notFound' });
-  },
-};
-
 // Define 401 route
 FlowRouter.route('/not-authorized', {
   name: 'notAuthorized',
@@ -55,8 +32,31 @@ FlowRouter.route('/forbidden', {
   },
 });
 
+// Define 404 route
+FlowRouter.notFound = {
+  action () {
+    BlazeLayout.render('masterLayout', { main: 'notFound' });
+  },
+};
+
 const redirectToCatalogue = function () {
   FlowRouter.go('catalogue');
+};
+
+const requireAdminRole = function () {
+  // Get user ID
+  const userId = Meteor.userId();
+
+  if (userId) {
+    const userIsAdmin = Roles.userIsInRole(userId, ['admin']);
+
+    if (!userIsAdmin) {
+      // User is not authorized to access route
+      FlowRouter.go('notAuthorized');
+    }
+  } else {
+    FlowRouter.go('signIn');
+  }
 };
 
 FlowRouter.triggers.enter([redirectToCatalogue], { only: ['forgotPwd'] });

--- a/core/client/lib/router.js
+++ b/core/client/lib/router.js
@@ -8,7 +8,9 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 import { Roles } from 'meteor/alanning:roles';
 
 Tracker.autorun(() => {
-  // There are specific cases that this reruns
+  // The Roles package actually depends on a subscription.
+  // If the subscription is not ready the Roles.userIsInRole method will always return false.
+  // That is used for checking of is user is admin
 
   // Make sure the roles subscription is ready & FlowRouter hasn't initialized already
   if (Roles.subscription.ready() && !FlowRouter._initialized) {

--- a/core/client/lib/router.js
+++ b/core/client/lib/router.js
@@ -7,14 +7,16 @@ import { BlazeLayout } from 'meteor/kadira:blaze-layout';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { Roles } from 'meteor/alanning:roles';
 
-FlowRouter.wait();
-
 Tracker.autorun(() => {
+  // There are specific cases that this reruns
+
+  // Make sure the roles subscription is ready & FlowRouter hasn't initialized already
   if (Roles.subscription.ready() && !FlowRouter._initialized) {
+    // Start routing
     return FlowRouter.initialize();
   }
-
-  return undefined;
+  // Otherwise wait
+  return FlowRouter.wait();
 });
 
 // Define group for routes that require sign in

--- a/core/client/lib/router.js
+++ b/core/client/lib/router.js
@@ -1,10 +1,21 @@
 // Meteor packages imports
 import { Meteor } from 'meteor/meteor';
+import { Tracker } from 'meteor/tracker';
 
 // Meteor contributed packages imports
 import { BlazeLayout } from 'meteor/kadira:blaze-layout';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import { Roles } from 'meteor/alanning:roles';
+
+FlowRouter.wait();
+
+Tracker.autorun(() => {
+  if (Roles.subscription.ready() && !FlowRouter._initialized) {
+    return FlowRouter.initialize();
+  }
+
+  return undefined;
+});
 
 // Define group for routes that require sign in
 const signedIn = FlowRouter.group({

--- a/core/client/userMenu.html
+++ b/core/client/userMenu.html
@@ -14,28 +14,28 @@
     </a>
     <ul class="dropdown-menu">
       <li>
-        <a href="{{pathFor 'profile' }}">
+        <a href="{{ pathFor 'profile' }}">
           {{_ "userMenu_profile" }}
         </a>
       </li>
       <li>
-        <a href="{{pathFor 'account' }}">
+        <a href="{{ pathFor 'account' }}">
           {{_ "userMenu_account" }}
         </a>
       </li>
       {{# if isInRole 'admin' }}
       <li>
-        <a href="{{pathFor 'branding' }}">
+        <a href="{{ pathFor 'branding' }}">
           {{_ "userMenu_branding" }}
         </a>
       </li>
       <li>
-        <a href="{{pathFor 'settings' }}">
+        <a href="{{ pathFor 'settings' }}">
           {{_ "userMenu_settings" }}
         </a>
       </li>
       <li>
-        <a href="{{pathFor 'proxies' }}">
+        <a href="{{ pathFor 'proxies' }}">
           {{_ "userMenu_proxies" }}
         </a>
       </li>


### PR DESCRIPTION
Closes #2222 
Closes #2281 

- Replace `Meteor.user()._id;` to `Meteor.userId()`. It did the stack overflow
- Add FlowRouter.wait(). It's waiting for the subscription ready. I found this way in [this article](https://medium.com/@satyavh/using-flow-router-for-authentication-ba7bb2644f42#.6i9w52ka9). Look at sentence **UPDATE May 26th 2016**