### PR TITLE
Non admin add api

### DIFF
--- a/apis/client/lib/router.js
+++ b/apis/client/lib/router.js
@@ -5,16 +5,53 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
 
 // Meteor packages imports
 import { Meteor } from 'meteor/meteor';
-
+import { Tracker } from 'meteor/tracker';
 // Meteor contributed packages imports
 import { BlazeLayout } from 'meteor/kadira:blaze-layout';
 import { FlowRouter } from 'meteor/kadira:flow-router';
+// APINF imports
+import signedIn from '/core/client/lib/router';
+import Settings from '/settings/collection';
 
-FlowRouter.route('/apis/new', {
+FlowRouter.wait();
+
+Tracker.autorun(() => {
+  // The Roles package actually depends on a subscription.
+  // If the subscription is not ready the Roles.userIsInRole method will always return false.
+  // That is used for checking of does user have the admin role
+
+  // Make sure the roles subscription is ready & FlowRouter hasn't initialized already
+  if (Roles.subscription.ready() && !FlowRouter._initialized) {
+    // Start routing
+    return FlowRouter.initialize();
+  }
+  // Otherwise nothing
+  return undefined;
+});
+
+signedIn.route('/apis/new', {
   name: 'addApi',
-  action () {
-    BlazeLayout.render('masterLayout', { main: 'addApi' });
-  },
+   action () {
+    const userId = Meteor.userId();
+      // Check that user is logged in
+      if (userId) {
+       // Check if user is administrator
+        const userIsAdmin = Roles.userIsInRole(userId, ['admin']);
+        const settings = Settings.findOne();
+        if (settings) {
+          // Get access setting value
+          // If access field doesn't exist, these is false. Allow users to add an API on default
+          const onlyAdminsCanAddApis = settings.access ? settings.access.onlyAdminsCanAddApis : false;
+         // Allow user to add an API because not only for admin
+         console.log('setting value=',onlyAdminsCanAddApis);
+          if (!userIsAdmin && !onlyAdminsCanAddApis) {
+          // User is not authorized to access route
+              FlowRouter.go('notAuthorized');
+          }} else {
+               BlazeLayout.render('masterLayout', { main: 'addApi' });
+            }; //else
+      }; //if userid
+  }, //action
 });
 
 FlowRouter.route('/apis/import', {

--- a/apis/client/lib/router.js
+++ b/apis/client/lib/router.js
@@ -5,6 +5,7 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
 
 // Meteor packages imports
 import { Meteor } from 'meteor/meteor';
+import { Mongo } from 'meteor/mongo';
 import { Tracker } from 'meteor/tracker';
 // Meteor contributed packages imports
 import { BlazeLayout } from 'meteor/kadira:blaze-layout';
@@ -12,6 +13,7 @@ import { FlowRouter } from 'meteor/kadira:flow-router';
 // APINF imports
 import signedIn from '/core/client/lib/router';
 import Settings from '/settings/collection';
+
 
 FlowRouter.wait();
 
@@ -21,6 +23,7 @@ Tracker.autorun(() => {
   // That is used for checking of does user have the admin role
 
   // Make sure the roles subscription is ready & FlowRouter hasn't initialized already
+
   if (Roles.subscription.ready() && !FlowRouter._initialized) {
     // Start routing
     return FlowRouter.initialize();
@@ -28,6 +31,17 @@ Tracker.autorun(() => {
   // Otherwise nothing
   return undefined;
 });
+
+function userAddApi () {
+         console.log('in setValue function');
+           let singleSetting = Settings.find();
+
+           if (singleSetting) {
+
+             const onlyAdminsCanAddApis = singleSetting.access ? singleSetting.access.onlyAdminsCanAddApis : false;
+                 return onlyAdminsCanAddApis;
+              };
+         };
 
 signedIn.route('/apis/new', {
   name: 'addApi',
@@ -37,22 +51,20 @@ signedIn.route('/apis/new', {
       if (userId) {
        // Check if user is administrator
         const userIsAdmin = Roles.userIsInRole(userId, ['admin']);
-        const settings = Settings.findOne();
-        if (settings) {
-          // Get access setting value
-          // If access field doesn't exist, these is false. Allow users to add an API on default
-          const onlyAdminsCanAddApis = settings.access ? settings.access.onlyAdminsCanAddApis : false;
-         // Allow user to add an API because not only for admin
-         console.log('setting value=',onlyAdminsCanAddApis);
-          if (!userIsAdmin && !onlyAdminsCanAddApis) {
+
+        setValue = userAddApi();
+
+        // if user is not admin and settings.access is true then should not allow to add api
+        if (!userIsAdmin && setValue) {
           // User is not authorized to access route
               FlowRouter.go('notAuthorized');
-          }} else {
+            } else {
                BlazeLayout.render('masterLayout', { main: 'addApi' });
             }; //else
-      }; //if userid
+        }; //if userid
   }, //action
 });
+
 
 FlowRouter.route('/apis/import', {
   name: 'importApiConfiguration',

--- a/core/client/navbar/navbar.js
+++ b/core/client/navbar/navbar.js
@@ -100,8 +100,7 @@ Template.navbar.helpers({
       // Get access setting value
       // If access field doesn't exist, these is false. Allow users to add an API on default
       const onlyAdminsCanAddApis = settings.access ? settings.access.onlyAdminsCanAddApis : false;
-
-      // Allow user to add an API because not only for admin
+     // Allow user to add an API because not only for admin
       if (!onlyAdminsCanAddApis) {
         return true;
       }
@@ -112,7 +111,6 @@ Template.navbar.helpers({
 
       // Check if current user is admin
       const userIsAdmin = Roles.userIsInRole(userId, ['admin']);
-
       return userIsAdmin;
     }
     // Return true because no settings are set


### PR DESCRIPTION
Refer to issue #2220 User can add Api when setting don't allow.

Issue:
  The code in the function userAddApi () in apis/client/lib/router.js , the Settings.find() is returning undefined. Can someone help why is it happenning?

Test Case failing:

1) If user is NonAdmin and  singleSetting.access.onlyAdminsCanAddApis = true .. then not authorised. This is failling because settings.findOne is returning undefined.

Thank you for the help.

