### PR TITLE
Add viewport meta tag

### DIFF
--- a/core/client/layouts/master_layout/head.html
+++ b/core/client/layouts/master_layout/head.html
@@ -5,4 +5,5 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
 
 <head>
   <link rel="icon" sizes="16x16 32x32" href="/favicon.png?v=2">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>


### PR DESCRIPTION
Closes #2155 

@apinf/developers please review ASAP, several ongoing tasks depend on this fix.

This line makes bootstrap classes for different screen types actually work as we expect them to work.

### Before fix: 

![before](https://cloud.githubusercontent.com/assets/7489044/24755498/2af31518-1ae3-11e7-83a4-d0688f69a882.png)

### After fix:

![after](https://cloud.githubusercontent.com/assets/7489044/24755513/4143477a-1ae3-11e7-94d5-ee681cb2b31d.png)


