### PR TITLE
Bugfix/no admin settings

### DIFF
--- a/apis/client/lib/router.js
+++ b/apis/client/lib/router.js
@@ -14,7 +14,14 @@ import { DocHead } from 'meteor/kadira:dochead';
 FlowRouter.route('/apis/new', {
   name: 'addApi',
   action () {
-    BlazeLayout.render('masterLayout', { main: 'addApi' });
+    // Check if API exists
+    Meteor.call('currentUserCanAddApi', (error, canAdd) => {
+      if (canAdd) {
+        BlazeLayout.render('masterLayout', { main: 'addApi' });
+      } else {
+        FlowRouter.go('forbidden');
+      }
+    });
   },
 });
 

--- a/apis/server/methods/authorization.js
+++ b/apis/server/methods/authorization.js
@@ -60,29 +60,28 @@ Meteor.methods({
     return api && api.currentUserCanManage();
   },
   currentUserCanAddApi () {
-    // Get Settigns
-    const settings = Settings.findOne();
-
     // Get current user Id
     const userId = Meteor.userId();
 
-    if (settings) {
-      // If the access permission 'only admins can add APIs' is defined, use it
-      // Otherwise, allow registered users to add APIs by default
-      const onlyAdminsCanAddApis = settings.access ? settings.access.onlyAdminsCanAddApis : false;
+    // Make sure user is logged in
+    if (userId === null) {
+      // Anonymous user not allowed to add API
+      return false;
+    }
+    // Get Settings (used to check for access permission)
+    const settings = Settings.findOne();
 
-      if (!onlyAdminsCanAddApis) {
-        // Allow user to add an API
-        return true;
-      }
+    // If the access permission 'only admins can add APIs' is defined, use it
+    // otherwise, allow users to add APIs by default
+    const onlyAdminsCanAddApis = settings.access ? settings.access.onlyAdminsCanAddApis : false;
 
-      // Otherwise only admin can add an API
+    // Check if only admins are allowed to add APIs
+    if (onlyAdminsCanAddApis) {
       // Make sure current user is admin
       return Roles.userIsInRole(userId, ['admin']);
     }
 
-    // Registered user can add an API then returns true
-    // Anonymous user can not add an API then returns false
-    return !!userId;
+    // Allow users to add APIs by default
+    return true;
   },
 });

--- a/apis/server/methods/authorization.js
+++ b/apis/server/methods/authorization.js
@@ -9,10 +9,12 @@ import { check } from 'meteor/check';
 
 // Meteor contributed packages imports
 import { Accounts } from 'meteor/accounts-base';
+import { Roles } from 'meteor/alanning:roles';
 import { ValidEmail } from 'meteor/froatsnook:valid-email';
 
 // Collection imports
 import Apis from '/apis/collection';
+import Settings from '/settings/collection';
 
 Meteor.methods({
   addAuthorizedUserByEmail (apiId, email) {
@@ -56,5 +58,30 @@ Meteor.methods({
 
     // Check if user can edit
     return api && api.currentUserCanManage();
+  },
+  currentUserCanAddApi () {
+    // Get Settigns
+    const settings = Settings.findOne();
+
+    // Get current user Id
+    const userId = Meteor.userId();
+
+    if (settings) {
+      // If access field doesn't exist, these is false. Allow users to add an API on default
+      const onlyAdminsCanAddApis = settings.access ? settings.access.onlyAdminsCanAddApis : false;
+
+      if (!onlyAdminsCanAddApis) {
+        // Allow user to add an API
+        return true;
+      }
+
+      // Otherwise only admin can add an API
+      // Make sure current user is admin
+      return Roles.userIsInRole(userId, ['admin']);
+    }
+
+    // Registered user can add an API then returns true
+    // Anonymous user can not add an API then returns false
+    return !!userId;
   },
 });

--- a/apis/server/methods/authorization.js
+++ b/apis/server/methods/authorization.js
@@ -67,7 +67,8 @@ Meteor.methods({
     const userId = Meteor.userId();
 
     if (settings) {
-      // If access field doesn't exist, these is false. Allow users to add an API on default
+      // If the access permission 'only admins can add APIs' is defined, use it
+      // Otherwise, allow registered users to add APIs by default
       const onlyAdminsCanAddApis = settings.access ? settings.access.onlyAdminsCanAddApis : false;
 
       if (!onlyAdminsCanAddApis) {


### PR DESCRIPTION
Closes #2220 
- User does not have permissions to add an API if user is anonymous
- - User does not have permissions to add an API if settings "Only administrator can add an API" and user is not admin

@apinf/developers Ready for review