### PR TITLE
Fix api logo subscription only if exists

### DIFF
--- a/apis/logo/upload/client/upload.js
+++ b/apis/logo/upload/client/upload.js
@@ -22,8 +22,10 @@ Template.uploadApiLogo.onCreated(function () {
     // Get Logo ID of current API using reactive way
     const apiLogoFileId = Template.currentData().api.apiLogoFileId;
 
-    // Subscribe to current API logo
-    instance.subscribe('currentApiLogo', apiLogoFileId);
+    if (apiLogoFileId) {
+      // Subscribe to current API logo
+      instance.subscribe('currentApiLogo', apiLogoFileId);
+    }
   });
 });
 


### PR DESCRIPTION
This fix an error that occur on server side when accessing to an api profile page that doesn't have a logo.
Now we subscribe to the currentApiLogo publication only if the api have a logo.