### PR TITLE
Add margin between API page header and navbar

### DIFF
--- a/apis/client/profile/header/header.less
+++ b/apis/client/profile/header/header.less
@@ -15,6 +15,7 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
   color: #666;
   background-color: #fafafa;
   border-bottom: 1px solid #eee;
+  margin-top: 2em;
 
   #api-header {
     display: inline;


### PR DESCRIPTION
After implement footer on every page I found that API page header doesn't have margin-top


