### PR TITLE
Ensure API document is available before returning name

### DIFF
--- a/about/client/about.html
+++ b/about/client/about.html
@@ -33,7 +33,7 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
               Apinf
             </dt>
             <dd>
-              0.44.0
+              0.44.1
             </dd>
             <dt>
               API Umbrella

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apinf",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "API management portal and proxy.",
   "main": "index.js",
   "directories": {

--- a/proxy_backends/collection/helpers.js
+++ b/proxy_backends/collection/helpers.js
@@ -15,7 +15,6 @@ ProxyBackends.helpers({
     const api = Apis.findOne(apiId);
 
     // Make sure API was found before accessing name property
-
     if (api) {
       // Return API Name
       return api.name;

--- a/proxy_backends/collection/helpers.js
+++ b/proxy_backends/collection/helpers.js
@@ -13,7 +13,12 @@ ProxyBackends.helpers({
     const apiId = this.apiId;
     // Get API
     const api = Apis.findOne(apiId);
-    // Return API Name
-    return api.name;
+
+    // Make sure API was found before accessing name property
+
+    if (api) {
+      // Return API Name
+      return api.name;
+    }
   },
 });


### PR DESCRIPTION
Closes #2528 

Note, we will need to make a new patch-level release for this hotfix.