### PR TITLE
Fix connection API to Proxy

### DIFF
--- a/apis/client/profile/details/details.js
+++ b/apis/client/profile/details/details.js
@@ -51,12 +51,13 @@ Template.apiDetails.helpers({
     // Get reference to template instance
     const instance = Template.instance();
 
+    // Get proxyBackend from template data
+    const proxyBackend = instance.data.proxyBackend;
+
     // placeholder for output URL
     let proxyUrl;
 
-    if (instance.data.proxyBackend) {
-      // Get proxyBackend from template data
-      const proxyBackend = instance.data.proxyBackend;
+    if (proxyBackend && proxyBackend.type === 'apiUmbrella') {
       // Get the proxy settings
       const proxy = Proxies.findOne(proxyBackend.proxyId);
       // Get Proxy host

--- a/proxy_backends/client/form/autoform.js
+++ b/proxy_backends/client/form/autoform.js
@@ -51,7 +51,7 @@ AutoForm.hooks({
                 }
 
                   // If success, attach API Umbrella backend ID to API
-                if (_.get(response, 'response.result.data.api')) {
+                if (_.has(response, 'result.data.api')) {
                     // Get the API Umbrella ID for newly created backend
                   const umbrellaBackendId = response.result.data.api.id;
 

--- a/proxy_backends/client/form/form.html
+++ b/proxy_backends/client/form/form.html
@@ -28,7 +28,7 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
     <!-- API Umbrella -->
     {{# if equals proxy.type "apiUmbrella" }}
 
-      {{> apiUmbrellaProxyForm proxy=proxy apiUmbrella=apiUmbrella api=api }}
+      {{> apiUmbrellaProxyForm proxy=proxy proxyHost=proxyHost api=api }}
 
     {{/ if }}
 

--- a/proxy_backends/client/form/form.js
+++ b/proxy_backends/client/form/form.js
@@ -64,53 +64,12 @@ Template.proxyBackend.onCreated(() => {
 });
 
 Template.proxyBackend.helpers({
-  apiHost () {
-    // Get API information
-    const api = this.api;
-
-    // Construct URL object for API URL
-    const apiUrl = new URI(api.url);
-
-    // Return the API URL protocol
-    return apiUrl.host();
-  },
-  apiPortHelper () {
-    // Get API information
-    const api = this.api;
-
-    // Construct URL object for API URL
-    const apiUrl = new URI(api.url);
-
-    // Return the API URL protocol
-    const protocol = apiUrl.protocol();
-
-    // Common default ports for HTTP/HTTPS
-    if (protocol === 'https') {
-      return 443;
-    }
-
-    if (protocol === 'http') {
-      return 80;
-    }
-
-    return '';
-  },
   apiProxySettings () {
     // Get API ID
     const apiId = this.api._id;
 
     // Look for existing proxy backend document for this API
     return ProxyBackends.findOne({ apiId });
-  },
-  apiUrlProtocol () {
-    // Get the API information
-    const api = this.api;
-
-    // Construct URL object for API URL
-    const apiUrl = new URI(api.url);
-
-    // Return the API URL protocol
-    return apiUrl.protocol();
   },
   formType () {
     const instance = Template.instance();

--- a/proxy_backends/client/form/proxies/api_umbrella/api_umbrella.js
+++ b/proxy_backends/client/form/proxies/api_umbrella/api_umbrella.js
@@ -1,0 +1,54 @@
+/* Copyright 2017 Apinf Oy
+This file is covered by the EUPL license.
+You may obtain a copy of the licence at
+https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
+
+// Meteor packages imports
+import { Template } from 'meteor/templating';
+
+// Npm packages imports
+import URI from 'urijs';
+
+Template.apiUmbrellaProxyForm.helpers({
+  apiHost () {
+    // Get API information
+    const api = this.api;
+
+    // Construct URL object for API URL
+    const apiUrl = new URI(api.url);
+
+    // Return the API URL protocol
+    return apiUrl.host();
+  },
+  apiPortHelper () {
+    // Get API information
+    const api = this.api;
+
+    // Construct URL object for API URL
+    const apiUrl = new URI(api.url);
+
+    // Return the API URL protocol
+    const protocol = apiUrl.protocol();
+
+    // Common default ports for HTTP/HTTPS
+    if (protocol === 'https') {
+      return 443;
+    }
+
+    if (protocol === 'http') {
+      return 80;
+    }
+
+    return '';
+  },
+  apiUrlProtocol () {
+    // Get the API information
+    const api = this.api;
+
+    // Construct URL object for API URL
+    const apiUrl = new URI(api.url);
+
+    // Return the API URL protocol
+    return apiUrl.protocol();
+  },
+});


### PR DESCRIPTION
Closes #2594 
Closes #2580


- After moving Form for API Umbrella proxy backend configuration to own template, some values wasn't available for apiUmbrella new template.

- Incorrect using of  `_.get()` lodash function also doesn't let adding Proxy Backend to API Umbrella proxy

### Changes 
- Move related helpers for apiUmbrella template
- Removed unrelated helpers from common template
- Get proxyHost to apiUmbrella template via Instance data
- Change `_.get` function to `_.has` function because _.has function returns boolean value instead of value
- Set correct `'path'` parameter in `_.has` function
- Hide proxy host if proxy is EMQ (API page)