### PR TITLE
Removed site title from Privacy and Terms of use templates

### DIFF
--- a/branding/client/privacy_policy/privacyPolicy.html
+++ b/branding/client/privacy_policy/privacyPolicy.html
@@ -6,7 +6,7 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
 <template name="privacyPolicy">
   {{# if branding.privacyPolicy }}
     <div class="container">
-      <h1>{{ branding.siteTitle }} {{_ "privacyPolicy_title" }}</h1>
+      <h1>{{_ "privacyPolicy_title" }}</h1>
         {{{ branding.privacyPolicy }}}
     </div>
   {{ else }}

--- a/branding/client/terms_of_use/termsOfUse.html
+++ b/branding/client/terms_of_use/termsOfUse.html
@@ -6,7 +6,7 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
 <template name="termsOfUse">
   {{# if branding.termsOfUse }}
     <div class="container">
-      <h1>{{ branding.siteTitle }} {{_ "termsOfUse_title" }}</h1>
+      <h1>{{_ "termsOfUse_title" }}</h1>
         {{{ branding.termsOfUse }}}
     </div>
   {{ else }}


### PR DESCRIPTION
Closes #2628 

Removed site title from Privacy and Terms of use templates.
