### PR TITLE
Replace path "/users/{id}" into related folder

### DIFF
--- a/core/server/api.js
+++ b/core/server/api.js
@@ -246,30 +246,7 @@ ApiV1.swagger = {
       },
 
       '/users/{id}': {
-        get: {
-          tags: [
-            UserFields.struct.tags.users,
-          ],
-          description: 'Returns user data with given ID.',
-          parameters: [
-            UserFields.struct.params.userId,
-          ],
-
-          responses: {
-            200: {
-              description: 'Data of identified user.',
-            },
-            401: {
-              description: 'Authentication is required',
-            },
-            403: {
-              description: 'User does not have permission.',
-            },
-            404: {
-              description: 'No user found with given UserID.',
-            },
-          },
-        },
+        get: {},
         delete: {
           tags: [
             UserFields.struct.tags.users,

--- a/users/collection/server/api.js
+++ b/users/collection/server/api.js
@@ -18,6 +18,30 @@ import Organizations from '/organizations/collection';
 import _ from 'lodash';
 
 
+ApiV1.swagger.meta.paths['/users/{id}'].get = {
+  tags: [
+    ApiV1.swagger.tags.users,
+  ],
+  description: 'Returns user data with given ID.',
+  parameters: [
+    ApiV1.swagger.params.userId,
+  ],
+  responses: {
+    200: {
+      description: 'Data of identified user.',
+    },
+    401: {
+      description: 'Authentication is required',
+    },
+    403: {
+      description: 'User does not have permission.',
+    },
+    404: {
+      description: 'No user found with given UserID.',
+    },
+  },
+};
+
 // Generates: POST on /api/v1/users and GET, DELETE /api/v1/users/:id for
 // Meteor.users collection
 ApiV1.addCollection(Meteor.users, {
@@ -192,20 +216,6 @@ ApiV1.addCollection(Meteor.users, {
     },
     get: {
       authRequired: true,
-      swagger: {
-        tags: [
-          ApiV1.swagger.tags.users,
-        ],
-        description: 'Returns user with given ID.',
-        parameters: [
-          ApiV1.swagger.params.userId,
-        ],
-        responses: {
-          200: {
-            description: 'One user.',
-          },
-        },
-      },
       action () {
       // Get requestor's id
         const requestorId = this.userId;


### PR DESCRIPTION
- Remove path "/users/{id}" from ApiV1.swagger.meta.paths in file "core/server/api.js", save a placeholder
- Remove swagger part from origin REST API file. Because of restivus-swagger doesn't create properly Swagger documentation for Users collection, this part was removed. Now it allows us two different part: one of this provides the only feature for creating Swagger file (ApiV1.swagger.meta.paths) and another one provides only logic for REST API

Related to #2648 (issue)
Repated to #2651 (PR)

@matleppa Please, review this PR. 
Look at Swagger file - it is still correct. Call couple request to `/users/{id}` - it still works properly.
