### PR TITLE
Fix double tooltip in toolbar

### DIFF
--- a/api_catalog/client/toolbar/toolbar.html
+++ b/api_catalog/client/toolbar/toolbar.html
@@ -51,14 +51,14 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
           <div class="btn-group navbar-btn" role="group" aria-label="Sort direction" data-toggle="buttons">
             <label
                    class="btn btn-default toolbar-tooltip active"
-                   title="{{_ 'catalogue_toolbar_sortMenuOptions_sortAscending' }}"
+                   data-original-title="{{_ 'catalogue_toolbar_sortMenuOptions_sortAscending' }}"
                    id="sortDirection-ascending">
               <input type="radio" name="sort-direction" id="sort-ascending" value="ascending" checked>
               <i class="fa fa-sort-amount-asc" aria-hidden="true"></i>
             </label>
             <label
                    class="btn btn-default toolbar-tooltip"
-                   title="{{_ 'catalogue_toolbar_sortMenuOptions_sortDescending' }}"
+                   data-original-title="{{_ 'catalogue_toolbar_sortMenuOptions_sortDescending' }}"
                    id="sortDirection-descending">
               <input type="radio" name="sort-direction" id="sort-descending" value="descending">
               <i class="fa fa-sort-amount-desc" aria-hidden="true"></i>
@@ -88,14 +88,14 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
           <div class="btn-group navbar-btn" role="group" aria-label="View mode" data-toggle="buttons">
             <label
                    class="btn btn-default toolbar-tooltip active"
-                   title="{{_ 'catalogue_toolbar_viewMode_grid' }}"
+                   data-original-title="{{_ 'catalogue_toolbar_viewMode_grid' }}"
                    id="viewMode-grid">
               <input type="radio" name="view-mode" id="grid-mode" value="grid" checked>
               <i class="fa fa-th-large" aria-hidden="true"></i>
             </label>
             <label
                    class="btn btn-default toolbar-tooltip"
-                   title="{{_ 'catalogue_toolbar_viewMode_table' }}"
+                   data-original-title="{{_ 'catalogue_toolbar_viewMode_table' }}"
                    id="viewMode-table">
               <input type="radio" name="view-mode" id="table-mode" value="table">
               <i class="fa fa-table" aria-hidden="true"></i>

--- a/organizations/client/catalog/toolbar/toolbar.html
+++ b/organizations/client/catalog/toolbar/toolbar.html
@@ -44,13 +44,13 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
         <div class="nav navbar-nav">
           <div class="btn-group navbar-btn" role="group" aria-label="Sort Direction" data-toggle="buttons">
             <label class="btn btn-default toolbar-tooltip active" id="organization-sort-ascending"
-                title="{{_ 'organizationCatalog_toolbar_sortMenuOptions_sortAscending' }}">
+                   data-original-title="{{_ 'organizationCatalog_toolbar_sortMenuOptions_sortAscending' }}">
               <input type="radio" class= "filter-sort-control" name="sortDirection" value="ascending">
               <i class="fa fa-sort-amount-asc" aria-hidden="true"></i>
             </label>
             <label
                 class="btn btn-default toolbar-tooltip" id="organization-sort-descending"
-                title="{{_ 'organizationCatalog_toolbar_sortMenuOptions_sortDescending' }}">
+                data-original-title="{{_ 'organizationCatalog_toolbar_sortMenuOptions_sortDescending' }}">
               <input type="radio" class= "filter-sort-control" name="sortDirection" value="descending">
               <i class="fa fa-sort-amount-desc" aria-hidden="true"></i>
             </label>
@@ -75,14 +75,14 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
             <label
                 for="grid-view"
                 class="btn btn-default toolbar-tooltip active"
-                title="{{_ 'organizationCatalog_toolbar_viewMode_grid' }}">
+                data-original-title="{{_ 'organizationCatalog_toolbar_viewMode_grid' }}">
               <input type="radio" class= "filter-sort-control" name="viewMode" value="grid">
               <i class="fa fa-th-large" aria-hidden="true"></i>
             </label>
             <label
                 for="table-view"
                 class="btn btn-default toolbar-tooltip"
-                title="{{_ 'organizationCatalog_toolbar_viewMode_table' }}">
+                data-original-title="{{_ 'organizationCatalog_toolbar_viewMode_table' }}">
               <input type="radio" class= "filter-sort-control" name="viewMode" value="table">
               <i class="fa fa-table" aria-hidden="true"></i>
             </label>


### PR DESCRIPTION
Closes #2436 

### Changes 
Set correct attribute for tooltip

For both catalog rename attribute "title" to "data-original-title" for fixing double tooltips after changing language
