### PR TITLE
Enhancement/display feedback author

### DIFF
--- a/core/lib/i18n/en.i18n.json
+++ b/core/lib/i18n/en.i18n.json
@@ -291,6 +291,7 @@
   "feedbackItem_topic": "Topic",
   "feedbackItem_editButton_text": "Edit",
   "feedbackItem_deleteButton_text": "Delete",
+  "feedbackItem_sentBy_text": "Sent by",
   "feedbackItem_usernotloggedin_errorMessage": "Error: Please sign in to vote",
   "feedback_feedbackForm_button": "Send feedback",
   "feedback_feedbackForm_description": "We welcome problem reports, feature ideas and general comments.",

--- a/core/lib/i18n/fi.i18n.json
+++ b/core/lib/i18n/fi.i18n.json
@@ -882,6 +882,7 @@
     "feedbackItem_topic": "Aihe",
     "feedbackItem_editButton_text": "Muokkaa",
     "feedbackItem_deleteButton_text": "Poista",
+    "feedbackItem_sentBy_text": "Sent by",
     "feedbackItem_usernotloggedin_errorMessage": "Virhe: Kirjaudu sis\u00e4\u00e4n \u00e4\u00e4nest\u00e4\u00e4ksesi",
     "feedback_feedbackForm_button": "L\u00e4het\u00e4 palaute",
     "feedback_feedbackForm_description": "Vikaraportit, ominaisuusideat ja yleiset kommentit ovat tervetulleita.",

--- a/core/lib/i18n/fi.i18n.json
+++ b/core/lib/i18n/fi.i18n.json
@@ -882,7 +882,7 @@
     "feedbackItem_topic": "Aihe",
     "feedbackItem_editButton_text": "Muokkaa",
     "feedbackItem_deleteButton_text": "Poista",
-    "feedbackItem_sentBy_text": "Sent by",
+    "feedbackItem_sentBy_text": "L\u00e4hetti",
     "feedbackItem_usernotloggedin_errorMessage": "Virhe: Kirjaudu sis\u00e4\u00e4n \u00e4\u00e4nest\u00e4\u00e4ksesi",
     "feedback_feedbackForm_button": "L\u00e4het\u00e4 palaute",
     "feedback_feedbackForm_description": "Vikaraportit, ominaisuusideat ja yleiset kommentit ovat tervetulleita.",

--- a/feedback/client/item/item.html
+++ b/feedback/client/item/item.html
@@ -44,6 +44,10 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
       </p>
     </div>
     <div class="panel-footer">
+      {{_ "feedbackItem_sentBy_text" }}
+      <b>
+        {{ item.author }}
+      </b>
       <i>
         {{ relativeTimeStamp item.createdAt }}
       </i>

--- a/feedback/collection/helpers.js
+++ b/feedback/collection/helpers.js
@@ -28,6 +28,12 @@ Feedback.helpers({
     const sum = ss.sum(votes);
     return sum;
   },
+  author () {
+    // Fetch only the author's username for current feedback
+    const author = Meteor.users.findOne(this.authorId)
+
+    return author.username
+  },
   currentUserCanEdit () {
     // Get current userId
     const userId = Meteor.userId();

--- a/feedback/collection/helpers.js
+++ b/feedback/collection/helpers.js
@@ -30,9 +30,9 @@ Feedback.helpers({
   },
   author () {
     // Fetch only the author's username for current feedback
-    const author = Meteor.users.findOne(this.authorId)
+    const author = Meteor.users.findOne(this.authorId);
 
-    return author.username
+    return author.username;
   },
   currentUserCanEdit () {
     // Get current userId


### PR DESCRIPTION
Closes #2464

I added the feedback author's name just before the relative timestamp for a given feedback item. Like so:

![alt text](http://i.imgur.com/iKNYOpt.png)

## Changes

* Adds helper method to `Feedback` collection to fetch author username
* Adds "feedbackItem_sentBy_text" to the `i18n.json` files for English and Suomi* translations

Please help me with the Suomi translation. I added it but I'm not it is the correct usage of the word.