### PR TITLE
Make sure Proxy instance is available before getting name

### DIFF
--- a/apinf_packages/dashboard/client/analytic/header/header.js
+++ b/apinf_packages/dashboard/client/analytic/header/header.js
@@ -36,6 +36,10 @@ Template.apiAnalyticPageHeader.helpers({
     const proxyId = Template.instance().proxyId;
     const proxy = Proxies.findOne(proxyId);
 
-    return proxy.name;
+    if (proxy) {
+      return proxy.name;
+    }
+
+    return '';
   },
 });


### PR DESCRIPTION
Closes #2916 

### Changes
- Make sure Proxy instance is available before display proxy name
- It happens when a user navigates from API Analytic page to Dashboard directly via navbar