### PR TITLE
Change MongoDB query operator

### DIFF
--- a/apinf_packages/apis/collection/server/publications.js
+++ b/apinf_packages/apis/collection/server/publications.js
@@ -81,7 +81,7 @@ Meteor.publishComposite('apiComposite', function (slug) {
           });
 
           // Publish feedback authors
-          return Meteor.users.find({ $or: authorIds });
+          return Meteor.users.find({ _id: { $in: authorIds } });
         },
       },
       {


### PR DESCRIPTION
Related to PR #2915

Found problem: if an API doesn't have feedback then the page is blank
@matleppa Please check the next cases:

1. Create an API and feedbacks on the page
2. Create an API w/out feedbacks
- Open both API as admin
- Open both API as anonym
- Open both API as API manager of this API
- Open both API as author feedback