### PR TITLE
Delete related proxy backend when proxy is removing

### DIFF
--- a/apinf_packages/core/helper_functions/promisify_call.js
+++ b/apinf_packages/core/helper_functions/promisify_call.js
@@ -9,6 +9,7 @@ import { Meteor } from 'meteor/meteor';
 // Validates Promisify Meteor.call, for better response handling.
 export default function promisifyCall (...args) {
   return new Promise((resolve, reject) => {
+    // Call function with arguments and callback function
     Meteor.call(...args, (err, response) => {
       return err ? reject(err) : resolve(response);
     });

--- a/apinf_packages/proxies/client/remove/remove.js
+++ b/apinf_packages/proxies/client/remove/remove.js
@@ -1,9 +1,10 @@
 /* Copyright 2017 Apinf Oy
-This file is covered by the EUPL license.
-You may obtain a copy of the licence at
-https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
+ This file is covered by the EUPL license.
+ You may obtain a copy of the licence at
+ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
 
 // Meteor packages imports
+import { Meteor } from 'meteor/meteor';
 import { Template } from 'meteor/templating';
 
 // Meteor contributed packages imports
@@ -13,7 +14,6 @@ import { sAlert } from 'meteor/juliancwirko:s-alert';
 
 // Collection imports
 import ProxyBackends from '/apinf_packages/proxy_backends/collection';
-import Proxies from '../../collection';
 
 Template.removeProxy.onCreated(function () {
   const proxyId = Template.currentData().proxy._id;
@@ -38,18 +38,30 @@ Template.removeProxy.helpers({
 });
 
 Template.removeProxy.events({
-  'click #confirm-remove-proxy': function () {
+  'click #confirm-remove-proxy': (event) => {
+    const button = event.currentTarget;
+
     const proxyId = Template.currentData().proxy._id;
 
     // Check proxyId
     if (proxyId) {
-      Proxies.remove(proxyId);
+      // Disabled button while request is in process
+      button.disabled = true;
+      // Remove proxy and all related proxy backends configurations
+      Meteor.call('removeProxy', proxyId, (err) => {
+        // Display error if something went wrong
+        if (err) sAlert.error(err);
+
+        // Enabled button when request is end
+        button.disabled = false;
+
+        // Hide form
+        Modal.hide('removeProxy');
+      });
     } else {
       // Show alert of failed removal
       const errorMessage = TAPi18n.__('removeProxy_errorMessage');
       sAlert.error(errorMessage);
     }
-
-    Modal.hide('removeProxy');
   },
 });

--- a/apinf_packages/proxies/server/methods.js
+++ b/apinf_packages/proxies/server/methods.js
@@ -1,0 +1,66 @@
+/* Copyright 2017 Apinf Oy
+ This file is covered by the EUPL license.
+ You may obtain a copy of the licence at
+ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
+
+// Meteor packages imports
+import { Meteor } from 'meteor/meteor';
+import { check } from 'meteor/check';
+
+// Collection imports
+import Proxies from '/apinf_packages/proxies/collection';
+import ProxyBackends from '/apinf_packages/proxy_backends/collection';
+
+// APInf imports
+import promisifyCall from '/apinf_packages/core/helper_functions/promisify_call';
+
+Meteor.methods({
+  removeProxy (proxyId) {
+    check(proxyId, String);
+    // Placeholder
+    const promises = [];
+
+    // Get all proxy backends are connected to removing Proxy
+    ProxyBackends.find({ proxyId }).forEach((proxyBackend) => {
+      // Get ID of related API Umbrella backend
+      const umbrellaBackendId = proxyBackend.apiUmbrella.id;
+
+      // Create a personal promise for each proxy backend
+      // Promise to delete backend from API Umbrella
+      const promise = promisifyCall(
+        'deleteApiBackendOnApiUmbrella', umbrellaBackendId, proxyId
+      )
+        .then(() => {
+          // Promise to publish changes on API Umbrella
+          promisifyCall(
+            'publishApiBackendOnApiUmbrella', umbrellaBackendId, proxyId
+          );
+        })
+        .then(() => {
+          // Remove Proxy backend configuration from database
+          ProxyBackends.remove(proxyBackend._id);
+        })
+        .catch(err => {
+          throw new Meteor.Error(err);
+        });
+
+      // Store promise
+      promises.push(promise);
+    });
+
+    return Promise.all(promises)
+      .then(
+        // On success result
+        () => {
+          // If all proxy backends were removed successfully from API Umbrella and database
+          // Then remove proxy
+          Proxies.remove(proxyId);
+        },
+        // On error result
+        (err) => {
+          throw new Meteor.Error(err);
+        }
+      );
+  },
+});
+


### PR DESCRIPTION
Closes #2937 

1. Update promisifyCall function, make it more general
2. Remove all related proxy backends if proxy is removing …
- Remove Proxy Backends from API Umbrella 
- Publish changes 
- Remove Proxy Backends from Database 
- Disable button "yes" in middle of remove process 
- Hide modal form after all

### Steps for reproduce
1. Create a tested proxy with correct data
2. Create couple APIs and connect them to the tested proxy
3. Go to Proxy settings and click on "Remove" button
4. Click on "Yes" button in modal form

### Expected result
1. Proxy settings were removed success
1. APIs are not connected to any Proxy
1. A user can connect API again w/out problem