### PR TITLE
Add a new migration step 10

### DIFF
--- a/apinf_packages/core/migrations/server/10-add-proxy-type.js
+++ b/apinf_packages/core/migrations/server/10-add-proxy-type.js
@@ -1,0 +1,22 @@
+/* Copyright 2017 Apinf Oy
+This file is covered by the EUPL license.
+You may obtain a copy of the licence at
+https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
+
+// Meteor contributed packages imports
+import { Migrations } from 'meteor/percolate:migrations';
+
+// Collection imports
+import ProxyBackends from '/apinf_packages/proxy_backends/collection';
+
+Migrations.add({
+  version: 10,
+  name: 'Ensure all proxy backends have the type field',
+  up () {
+    // Update proxy backends are connected to API Umbrella proxy type
+    ProxyBackends.update(
+      { type: { $exists: false }, 'apiUmbrella.name': { $exists: true } },
+      { $set: { type: 'apiUmbrella' } }
+      );
+  },
+});


### PR DESCRIPTION
Closes #2956 

### How to reproduce bug with Production

1. `git checkout tags/0.44.1` -- select release when a proxy type was only one
2. Run meteor application. 
3. Connect API to Proxy.  Make sure API URL was changed on Details page
![joxi_screenshot_1506502168907 1](https://user-images.githubusercontent.com/20643403/30909384-90924298-a389-11e7-9333-ef6464cb465a.png)
![joxi_screenshot_1506502168907 2](https://user-images.githubusercontent.com/20643403/30909389-942c1294-a389-11e7-889f-09a187822d46.png)
4. `git checkout develop` -- select current release
5. Run meteor application. 
6. Navigate to early connected API. Make sure API URL input display no proxy url 
(The same result in the bug report. API is connected to proxy but API URL in Details is not Proxy URL)
7. Make sure Migration is unlocked. If it is not then updated "locked" field to false value
8. `git checkout bugfix/migration-step`
9. Make sure Migration ran up to 10 version
10. Check API again

### Expected result
API URL in Details equals Proxy URL