### PR TITLE
Return public URL to logo instead of internal id

### DIFF
--- a/apinf_packages/apis/server/api.js
+++ b/apinf_packages/apis/server/api.js
@@ -210,12 +210,23 @@ CatalogV1.addCollection(Apis, {
           ];
         }
 
+        // Fetch the list of APIs matching with conditions
+        const apiList = Apis.find(query, options).fetch();
+        // Replace internal logo id with correct link
+        if (apiList) {
+          apiList.forEach((api) => {
+            if (api.apiLogoFileId) {
+              api.apiLogoFileId = api.logoUrl();
+            }
+          });
+        }
+
         // Construct response
         return {
           statusCode: 200,
           body: {
             status: 'success',
-            data: Apis.find(query, options).fetch(),
+            data: apiList,
           },
         };
       },

--- a/apinf_packages/apis/server/api.js
+++ b/apinf_packages/apis/server/api.js
@@ -23,7 +23,7 @@ CatalogV1.swagger.meta.paths = {
   '/login': {
     post: {
       tags: [
-        CatalogV1.swagger.tags.login,
+        CatalogV1.swagger.tags.authentication,
       ],
       summary: 'Logging in.',
 
@@ -52,7 +52,7 @@ CatalogV1.swagger.meta.paths = {
   '/logout': {
     post: {
       tags: [
-        CatalogV1.swagger.tags.logout,
+        CatalogV1.swagger.tags.authentication,
       ],
       summary: 'Logging out.',
 

--- a/apinf_packages/apis/server/api.js
+++ b/apinf_packages/apis/server/api.js
@@ -210,13 +210,14 @@ CatalogV1.addCollection(Apis, {
           ];
         }
 
-        // Fetch the list of APIs matching with conditions
-        const apiList = Apis.find(query, options).fetch();
-        // Replace internal logo id (when exists) with correct link
-        apiList.forEach((api) => {
+        // Create new API list that is based on APIs collection with extended field logoUrl
+        const apiList = Apis.find(query, options).map((api) => {
+          // Make sure logo is uploaded
           if (api.apiLogoFileId) {
-            api.apiLogoFileId = api.logoUrl();
+            // Create a new field to store logo URL
+            api.logoUrl = api.logoUrl();
           }
+          return api;
         });
 
         // Construct response
@@ -298,10 +299,9 @@ CatalogV1.addCollection(Apis, {
           }
         }
 
-
-        // Replace internal logo id (when exists) with correct link
+        // Extend API structure with correct link to API logo
         if (api.apiLogoFileId) {
-          api.apiLogoFileId = api.logoUrl();
+          api.logoUrl = api.logoUrl();
         }
 
         // Construct response

--- a/apinf_packages/organizations/server/api.js
+++ b/apinf_packages/organizations/server/api.js
@@ -95,13 +95,14 @@ ManagementV1.addRoute('organizations', {
         ];
       }
 
-      // Fetch the list of Organizations matching with conditions
-      const organizationList = Organizations.find(query, options).fetch();
-      // Replace internal logo id (when exists) with correct link
-      organizationList.forEach((organization) => {
+      // Create new Organization list that is based on Organization collection with extended field logoUrl
+      const organizationList = Organizations.find(query, options).map((organization) => {
+        // Make sure logo is uploaded
         if (organization.organizationLogoFileId) {
-          organization.organizationLogoFileId = organization.logoUrl();
+          // Create a new field to store logo URL
+          organization.logoUrl = organization.logoUrl();
         }
+        return organization;
       });
 
       // Construct response
@@ -355,9 +356,9 @@ ManagementV1.addRoute('organizations/:id', {
         return errorMessagePayload(404, detailLine);
       }
 
-      // Replace internal logo id (when exists) with correct link
+      // When internal logo id exists, add also correct link
       if (organization.organizationLogoFileId) {
-        organization.organizationLogoFileId = organization.logoUrl();
+        organization.logoURL = organization.logoUrl();
       }
 
       return {

--- a/apinf_packages/organizations/server/api.js
+++ b/apinf_packages/organizations/server/api.js
@@ -95,12 +95,21 @@ ManagementV1.addRoute('organizations', {
         ];
       }
 
+      // Fetch the list of Organizations matching with conditions
+      const organizationList = Organizations.find(query, options).fetch();
+      // Replace internal logo id (when exists) with correct link
+      organizationList.forEach((organization) => {
+        if (organization.organizationLogoFileId) {
+          organization.organizationLogoFileId = organization.logoUrl();
+        }
+      });
+
       // Construct response
       return {
         statusCode: 200,
         body: {
           status: 'success',
-          data: Organizations.find(query, options).fetch(),
+          data: organizationList,
         },
       };
     },
@@ -344,6 +353,11 @@ ManagementV1.addRoute('organizations/:id', {
       if (!organization) {
         const detailLine = `Organization with specified ID (${this.urlParams.id}) is not found`;
         return errorMessagePayload(404, detailLine);
+      }
+
+      // Replace internal logo id (when exists) with correct link
+      if (organization.organizationLogoFileId) {
+        organization.organizationLogoFileId = organization.logoUrl();
       }
 
       return {

--- a/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
+++ b/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
@@ -27,13 +27,17 @@ const descriptionApis = {
   get: `
   ### Lists data of API with specified ID ###
 
-  Returns the API with specified ID, if a match is found.
+  Returns the API with specified ID, if a match is found. In case API is private,
+  only Admin user or API manager can get it.
 
   Example call:
 
       GET /apis/:id
 
   Result: returns the data of API identified with :id.
+
+  Note! The field X-User-Id in message header can be used
+  * to contain Admin/Manager user's ID, when indicated, that user is Admin/Manager
   `,
   // --------------------------------------------
   post: `

--- a/apinf_packages/rest_apis/lib/descriptions/catalog_texts.js
+++ b/apinf_packages/rest_apis/lib/descriptions/catalog_texts.js
@@ -80,6 +80,8 @@ Successful case:
 * the payload contains fields (except in HTTP 204 case)
   * status: value "success"
   * data: data of object(s)
+    * Note! Only fields, which have a value are returned in response message.
+      E.g. When API has no logo, no apiLogoFileId field is included in response message. 
 
 
 Unsuccessful case:

--- a/apinf_packages/rest_apis/server/catalog.js
+++ b/apinf_packages/rest_apis/server/catalog.js
@@ -45,9 +45,8 @@ CatalogV1.swagger = {
     },
   },
   tags: {
+    authentication: 'Authentication',
     api: 'APIs',
-    login: 'Login',
-    logout: 'Logout',
   },
   params: {
     api: {

--- a/apinf_packages/rest_apis/server/catalog.js
+++ b/apinf_packages/rest_apis/server/catalog.js
@@ -235,6 +235,10 @@ CatalogV1.swagger = {
         },
         apiLogoFileId: {
           type: 'string',
+          example: 'file-id',
+        },
+        logoURL: {
+          type: 'string',
           example: 'link-address-to-logo-image',
         },
       },

--- a/apinf_packages/rest_apis/server/catalog.js
+++ b/apinf_packages/rest_apis/server/catalog.js
@@ -199,7 +199,7 @@ CatalogV1.swagger = {
             example: 'user-id',
           },
         },
-        createdAt: {
+        created_at: {
           type: 'string',
           example: '2012-07-14T01:00:00+01:00',
         },
@@ -228,6 +228,14 @@ CatalogV1.swagger = {
               },
             },
           },
+        },
+        updated_at: {
+          type: 'string',
+          example: '2017-07-14T01:00:00+01:00',
+        },
+        apiLogoFileId: {
+          type: 'string',
+          example: 'link-address-to-logo-image',
         },
       },
     },

--- a/apinf_packages/rest_apis/server/management.js
+++ b/apinf_packages/rest_apis/server/management.js
@@ -46,10 +46,9 @@ ManagementV1.swagger = {
     },
   },
   tags: {
+    authentication: 'Authentication',
     organization: 'Organizations',
     users: 'Users',
-    login: 'Login',
-    logout: 'Logout',
   },
   params: {
     limit: {

--- a/apinf_packages/rest_apis/server/management.js
+++ b/apinf_packages/rest_apis/server/management.js
@@ -349,6 +349,15 @@ ManagementV1.swagger = {
             },
           },
         },
+        organizationLogoFileId: {
+          type: 'string',
+          example: 'file-id',
+        },
+        logoURL: {
+          type: 'string',
+          example: 'link-address-to-logo-image',
+        },
+
       },
     },
     loginRequest: {

--- a/apinf_packages/users/collection/server/api.js
+++ b/apinf_packages/users/collection/server/api.js
@@ -26,7 +26,7 @@ ManagementV1.swagger.meta.paths = {
   '/login': {
     post: {
       tags: [
-        ManagementV1.swagger.tags.login,
+        ManagementV1.swagger.tags.authentication,
       ],
       summary: 'Logging in.',
       description: descriptionLoginLogout.login,
@@ -54,7 +54,7 @@ ManagementV1.swagger.meta.paths = {
   '/logout': {
     post: {
       tags: [
-        ManagementV1.swagger.tags.logout,
+        ManagementV1.swagger.tags.authentication,
       ],
       summary: 'Logging out.',
       description: descriptionLoginLogout.logout,


### PR DESCRIPTION
Closes #2816 
Closes #2986 

## 2816
When API or Organization data is returned via REST API, it contains also logo id, it a logo exists. 
Instead of internal logo id the link to picture must be returned. 

## 2986
In REST API documentation endpoints Login and Logout should both be under Authentication tag not under separate tags.
