### PR TITLE
Fix Displaying of Swagger file

### DIFF
--- a/apinf_packages/apis/collection/helpers.js
+++ b/apinf_packages/apis/collection/helpers.js
@@ -204,7 +204,7 @@ Apis.helpers({
     const apiDocs = ApiDocs.findOne({ apiId });
 
     // Placeholder documentation Object
-    let documentation;
+    let documentation = '';
 
     // Placeholder documentation file Object
     let documentationFile;

--- a/apinf_packages/core/migrations/server/11-fix-api-docs.js
+++ b/apinf_packages/core/migrations/server/11-fix-api-docs.js
@@ -1,0 +1,23 @@
+/* Copyright 2017 Apinf Oy
+This file is covered by the EUPL license.
+You may obtain a copy of the licence at
+https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
+
+// Meteor contributed packages imports
+import { Migrations } from 'meteor/percolate:migrations';
+
+// Collection imports
+import apiDocs from '/apinf_packages/api_docs/collection';
+
+Migrations.add({
+  version: 11,
+  name: 'Fix api documents migration: change type File to Url',
+  up () {
+    // If documentation is uploaded as remote file but type is file
+    // Also make sure that file isn't uploaded as file (fileId doesn't exist)
+    apiDocs.update(
+      { remoteFileUrl: { $exists: true }, type: 'file', fileId: { $exists: false } },
+      { $set: { type: 'url' } }
+      );
+  },
+});


### PR DESCRIPTION
Closes #2791 

### Step for reproduce
1. Make sure migrations version is 1 and locked is false
2. Change to 0.42 version release `git checkout tags/0.42.0`
3. Create an API and add swagger file as URL
4. `git checkout develop`
5. Navigate to the API and open Documentation tab
6. Spinner is turned on (as expected. The same result on production site)
7. `git checkout bugfix/migration-for-docs`
8. Make sure migration version is updated to 11
5. Navigate to the API and open Documentation tab
10. Corrected working