### PR TITLE
Placeholder for API name is the empty string not undefined value

### DIFF
--- a/apinf_packages/proxy_backends/collection/helpers.js
+++ b/apinf_packages/proxy_backends/collection/helpers.js
@@ -19,7 +19,7 @@ ProxyBackends.helpers({
     const api = Apis.findOne(apiId);
 
     // placeholder for API name
-    let apiName;
+    let apiName = '';
 
     // Make sure API was found before accessing name property
     if (api) {


### PR DESCRIPTION
Closes #2961 

### Changes
- Dirty hack for apiName helper of Proxy Backend collection.

### Research result

- Proxy Backends are not removed in apinf.io site because ProxyBackend documents in collection don't have the field as `type`. Method `deleteProxyBackend` works when `type` exists

deleteProxyBackend:
https://github.com/apinf/platform/blob/0b1dc4ffa9e15692aa737f49cf2e379617c5bf07/apinf_packages/proxy_backends/server/methods.js#L25-L29

It has to be resolved in the next release when 10 step of migration will be run

10 step of migration:
https://github.com/apinf/platform/blob/0b1dc4ffa9e15692aa737f49cf2e379617c5bf07/apinf_packages/core/migrations/server/10-add-proxy-type.js#L12-L22

