### PR TITLE
Fixed: Filter only APIs with Swagger documentation

### DIFF
--- a/apinf_packages/api_catalog/client/toolbar/toolbar.html
+++ b/apinf_packages/api_catalog/client/toolbar/toolbar.html
@@ -50,25 +50,32 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
             </div>
           </form>
         </div>
-        
+
         {{# if currentUser }}
-        <div class="nav navbar-nav">
-          <div class="btn-group navbar-btn filter-options-menu" role="group" aria-label="Filter options" data-toggle="buttons">
-            <label class="btn btn-default active" id="filterBy-all">
-              <input type="radio" name="filter-options" value="all" checked>
-              {{_ "catalog_toolbar_filterOptions_showAll" }}
-            </label>
-            <label class="btn btn-default" id="filterBy-my-apis">
-              <input type="radio" name="filter-options" value="my-apis">
-              {{_ "catalog_toolbar_filterOptions_myApis" }}
-            </label>
-            <label class="btn btn-default" id="filterBy-my-bookmarks">
-              <input type="radio" name="filter-options" value="my-bookmarks">
-              {{_ "catalog_toolbar_filterOptions_myBookmarks" }}
-            </label>
+          <div class="nav navbar-nav">
+            <div class="btn-group navbar-btn filter-options-menu" role="group" aria-label="Filter options" data-toggle="buttons">
+              <label class="btn btn-default active" id="filterBy-all">
+                <input type="radio" name="filter-options" value="all" checked>
+                {{_ "catalog_toolbar_filterOptions_showAll" }}
+              </label>
+              <label class="btn btn-default" id="filterBy-my-apis">
+                <input type="radio" name="filter-options" value="my-apis">
+                {{_ "catalog_toolbar_filterOptions_myApis" }}
+              </label>
+              <label class="btn btn-default" id="filterBy-my-bookmarks">
+                <input type="radio" name="filter-options" value="my-bookmarks">
+                {{_ "catalog_toolbar_filterOptions_myBookmarks" }}
+              </label>
+            </div>
+            <div class="btn-group" data-toggle="buttons">
+              <label class="btn btn-default" id="filterBy-with-docs">
+                <input type="checkbox" name="filter-api-documentation" value="with-docs">
+                {{_ "catalog_toolbar_filterOptions_apisWithDocumentation" }}
+              </label>
+            </div>
           </div>
-        </div>
         {{/ if }}
+
         <div class="nav navbar-nav navbar-right">
           <a href="/rss/apis" target="_blank" class="rss-feed fa fa-rss-square fa-3x btn" title="{{_ 'apisRssIcon_tooltipText_Rss'}}">
           </a>

--- a/apinf_packages/api_catalog/client/toolbar/toolbar.js
+++ b/apinf_packages/api_catalog/client/toolbar/toolbar.js
@@ -48,6 +48,10 @@ Template.apiCatalogToolbar.events({
     // Set URL parameter
     FlowRouter.setQueryParams({ filterBy: event.target.value });
   },
+  'change [name=filter-api-documentation]': function (event) {
+    // Set URL parameter
+    FlowRouter.setQueryParams({ apisWithDocumentation: event.currentTarget.checked });
+  },
   'change [name=view-mode]': function (event) {
     // Set URL parameter
     FlowRouter.setQueryParams({ viewMode: event.target.value });

--- a/apinf_packages/api_docs/server/publications.js
+++ b/apinf_packages/api_docs/server/publications.js
@@ -9,6 +9,7 @@ import { Mongo } from 'meteor/mongo';
 import { check } from 'meteor/check';
 
 // Collection imports
+import ApiDocs from '/apinf_packages/api_docs/collection';
 import DocumentationFiles from '/apinf_packages/api_docs/files/collection';
 
 Meteor.publish(
@@ -26,3 +27,20 @@ Meteor.publish(
       },
     });
   });
+
+Meteor.publish('apisDocuments', () => {
+  // Construct query
+  const query = {
+    $or: [
+      {
+        remoteFileUrl: { $exists: true, $ne: null },
+      },
+      {
+        fileId: { $exists: true, $ne: null },
+      },
+    ],
+  };
+
+  // Return a cursor containing documents that contains either 'fileId' or 'remoteFileUrl'
+  return ApiDocs.find(query, { fields: { apiId: 1 } });
+});

--- a/apinf_packages/core/lib/i18n/en.i18n.json
+++ b/apinf_packages/core/lib/i18n/en.i18n.json
@@ -208,6 +208,7 @@
   "catalog_toolbar_filterOptions_myApis": "My APIs",
   "catalog_toolbar_filterOptions_showAll": "Show all",
   "catalog_toolbar_filterOptions_myBookmarks": "My bookmarks",
+  "catalog_toolbar_filterOptions_apisWithDocumentation": "APIs with Documentation",
   "catalog_toolbar_sortBy_title": "Sort by",
   "catalog_toolbar_sortMenuOptions_highRating": "Highest Rating",
   "catalog_toolbar_sortMenuOptions_mostBookmarked": "Most Bookmarked",


### PR DESCRIPTION
# Closes #2550

## Changes
- Done changes in api_catalog.js for applying additional filter for fetching 'APIs with Documentation'. 
- Done changes in toolbar.html and toolbar.js for creating additional filter 'APIs with Documentation' on APIs page. 
- Done changes in api_docs publication for creating a new publication 'apiIdsWithDocumentation' that will give us the apiIds of all APIs that has a documentation in apiDocs collection.


## Developer checklist
This checklist is to be completed by the PR developer:

- [x] Alternative solutions were compared/discussed before writing code
    - [x] trade-offs with this solution are considered acceptable
- [x] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [x] This pull request does not decrease project test coverage
- [x] If the code changes existing database collection(s), migration has been written
- [x] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @mauriciovieira  @Nazarah @marla-singer 

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [x] no browser console errors visible
    - [x] no server console errors visible
    - [x] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
