### PR TITLE
Change logic for "Last 24 hours" option of date range picker

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@
     "no-underscore-dangle": [
       2,
       {
-        "allow": ["_id", "__", "_initialized", "_config", "_debug"]
+        "allow": ["_id", "__", "_initialized", "_config", "_debug", "_d"]
       }
     ],
     "no-negated-condition": [

--- a/apinf_packages/dashboard/client/analytic/body/body.js
+++ b/apinf_packages/dashboard/client/analytic/body/body.js
@@ -40,11 +40,13 @@ Template.apiAnalyticPageBody.onCreated(function () {
         // Get request_path
         const proxyBackendPath = proxyBackend.apiUmbrella.url_matches[0].frontend_prefix;
 
-        // Get timeframe
-        const timeframe = FlowRouter.getQueryParam('timeframe');
+        // Get query parameter value
+        const queryParamValue = FlowRouter.getQueryParam('timeframe');
+        // Get values of timeframe & granularity
+        const [timeframe, granularity] = queryParamValue.split('-');
 
         // Make query to Elasticsearch for this page
-        const queryParams = queryForAnalyticPage(proxyBackendPath, timeframe);
+        const queryParams = queryForAnalyticPage(proxyBackendPath, timeframe, granularity);
 
         // Get URL of relevant ElasticSearch
         const elasticsearchHost = proxy.apiUmbrella.elasticsearch;

--- a/apinf_packages/dashboard/client/analytic/charts/requests_number/requests_number.js
+++ b/apinf_packages/dashboard/client/analytic/charts/requests_number/requests_number.js
@@ -99,19 +99,24 @@ Template.requestTimeline.onRendered(function () {
     // Get aggregated data for current chart
     const aggregationData = elasticsearchData.requests_over_time.buckets;
 
-    // Get current timeframe
-    const dateCount = FlowRouter.getQueryParam('timeframe');
+    // Get query parameter value
+    const queryParamValue = FlowRouter.getQueryParam('timeframe');
+    // Get timeframe & granularity values
+    const [dateCount, granularity] = queryParamValue.split('-');
+
+    // Generate today date and just current hour
+    const today = moment().millisecond(0).second(0).minute(0);
 
     const params = {
       // Date range must have equal length with dateCount value
       // To include also today, subtract one day less than count of days in period
-      startDate: moment().subtract(dateCount - 1, 'd'),
-      endDate: moment(),
-      // Interval is 1 day
+      endDate: today.clone(),
+      startDate: today.subtract(dateCount - 1, granularity),
       step: 1,
+      granularity,
       // TODO: internationalize date formatting
       // https://github.com/apinf/platform/issues/2900
-      format: 'MM/DD',
+      format: granularity === 'hour' ? 'H:mm' : 'MM/DD',
     };
 
     const labels = generateDate(params);

--- a/apinf_packages/dashboard/client/analytic/charts/response_time/response_time.js
+++ b/apinf_packages/dashboard/client/analytic/charts/response_time/response_time.js
@@ -8,6 +8,7 @@ import { ReactiveVar } from 'meteor/reactive-var';
 import { Template } from 'meteor/templating';
 
 // Meteor contributed packages import
+import { FlowRouter } from 'meteor/kadira:flow-router';
 import { TAPi18n } from 'meteor/tap:i18n';
 
 // Npm packages imports
@@ -84,6 +85,11 @@ Template.responseTimeTimeline.onRendered(function () {
 
   // Update chart when elasticsearchData was changed
   instance.autorun(() => {
+    // Get query parameter value
+    const queryParamValue = FlowRouter.getQueryParam('timeframe');
+    // Get value of granularity
+    const granularity = queryParamValue.split('-')[1];
+
     // Get ElasticSearch data
     const elasticsearchData = instance.elasticsearchData.get();
 
@@ -104,10 +110,12 @@ Template.responseTimeTimeline.onRendered(function () {
       return parseInt(responseTime, 10);
     });
 
+    const format = granularity === 'hour' ? 'H:mm' : 'MM/DD';
+
     // Create Labels values
     const labels = aggregationData.map(value => {
       // TODO: internationalize date formatting
-      return moment(value.key).format('MM/DD');
+      return moment(value.key).format(format);
     });
 
     // Update labels & data

--- a/apinf_packages/dashboard/client/analytic/query.js
+++ b/apinf_packages/dashboard/client/analytic/query.js
@@ -7,13 +7,13 @@
 // Npm packages imports
 import moment from 'moment';
 
-export default function queryForAnalyticPage (frontendPrefix, timeframe) {
+export default function queryForAnalyticPage (frontendPrefix, timeframe, interval) {
   // Plus one day to include current day in selection
-  const today = moment().add(1, 'days').format('YYYY-MM-DD');
-
-  const oneTimePeriodAgo = moment().subtract(timeframe - 1, 'days').format('YYYY-MM-DD');
+  const today = moment().add(1, interval)._d.getTime();
+  // Make it depends on timeframe & interval
+  const oneTimePeriodAgo = moment().subtract(timeframe - 1, interval)._d.getTime();
   // eslint-disable-next-line no-mixed-operators
-  const twoTimePeriodsAgo = moment().subtract(2 * timeframe - 1, 'days').format('YYYY-MM-DD');
+  const twoTimePeriodsAgo = moment().subtract(2 * timeframe - 1, interval)._d.getTime();
 
   // Delete a last slash
   const requestPath = frontendPrefix.slice(0, -1);
@@ -78,7 +78,7 @@ export default function queryForAnalyticPage (frontendPrefix, timeframe) {
             requests_over_time: {
               date_histogram: {
                 field: 'request_at',
-                interval: 'day',
+                interval,
               },
               aggs: {
                 // median response time over interval
@@ -141,7 +141,7 @@ export default function queryForAnalyticPage (frontendPrefix, timeframe) {
                 requests_over_time: {
                   date_histogram: {
                     field: 'request_at',
-                    interval: 'day',
+                    interval,
                   },
                   aggs: {
                     // Percentiles of response time over interval

--- a/apinf_packages/dashboard/client/analytic/view/view.js
+++ b/apinf_packages/dashboard/client/analytic/view/view.js
@@ -17,6 +17,15 @@ import {
   calculateTrend,
 } from '/apinf_packages/dashboard/lib/trend_helpers';
 
+Template.apiAnalyticView.onCreated(function () {
+  this.autorun(() => {
+    // Get query parameter value
+    const queryParamValue = FlowRouter.getQueryParam('timeframe');
+    // Get timeframe value
+    this.timeframe = queryParamValue.split('-')[0];
+  });
+});
+
 Template.apiAnalyticView.helpers({
   arrowDirection (parameter) {
     // Provide compared data
@@ -27,11 +36,10 @@ Template.apiAnalyticView.helpers({
     return percentageValue(parameter, this);
   },
   summaryComparing (parameter) {
-    // Get value of timeframe
-    const currentTimeframe = FlowRouter.getQueryParam('timeframe');
+    const instance = Template.instance();
 
     // Provide compared data
-    return summaryComparing(parameter, this, currentTimeframe);
+    return summaryComparing(parameter, this, instance.timeframe);
   },
   bucket () {
     const instance = Template.instance();

--- a/apinf_packages/dashboard/client/chart_helpers.js
+++ b/apinf_packages/dashboard/client/chart_helpers.js
@@ -11,15 +11,16 @@
  * @param {*} params.endDate - end date of range (included value)
  * @param {string} params.format - date format
  * @param {number} params.step - step of interval
+ * @param {string} params.granularity - granularity
  */
 export function generateDate (params) {
-  const { startDate, endDate, step, format } = params;
+  const { startDate, endDate, step, format, granularity } = params;
   // Placeholders for date
   const dateList = [];
   // Include endDate
   while (startDate <= endDate) {
     dateList.push(startDate.format(format));
-    startDate.add(step, 'days');
+    startDate.add(step, granularity);
   }
   return dateList;
 }

--- a/apinf_packages/dashboard/client/date_range_picker/toolbar.html
+++ b/apinf_packages/dashboard/client/date_range_picker/toolbar.html
@@ -5,13 +5,13 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
 
 <template name="dateRangePicker">
   <select name="timeframe" class="form-control" id="date-range-picker">
-    <option value="1">
+    <option value="24-hour">
       {{_ 'dateRangePicker_optionText_yesterday' }}
     </option>
-    <option value="7">
+    <option value="7-day">
       {{_ 'dateRangePicker_optionText_7days' }}
     </option>
-    <option value="30">
+    <option value="30-day">
       {{_ 'dateRangePicker_optionText_30days' }}
     </option>
   </select>

--- a/apinf_packages/dashboard/client/lib/routes.js
+++ b/apinf_packages/dashboard/client/lib/routes.js
@@ -26,8 +26,8 @@ signedIn.route('/dashboard', {
 
     if (!context.queryParams.timeframe) {
       // Initialize timeframe parameter if it doesn't specify
-      // Default value is 7
-      context.queryParams.timeframe = 7;
+      // It contains on timeframe value and granularity
+      context.queryParams.timeframe = '7-day';
     }
   }],
   name: 'dashboard',
@@ -41,8 +41,8 @@ signedIn.route('/analytic/:apiSlug', {
   triggersEnter: [(context) => {
     if (!context.queryParams.timeframe) {
       // Initialize timeframe parameter if it doesn't specify
-      // Default value is 7
-      context.queryParams.timeframe = 7;
+      // It contains on timeframe value and granularity
+      context.queryParams.timeframe = '7-day';
     }
   }],
   name: 'apiAnalyticPage',

--- a/apinf_packages/dashboard/client/view/overview/charts/median_response_time/median_response_time.js
+++ b/apinf_packages/dashboard/client/view/overview/charts/median_response_time/median_response_time.js
@@ -71,19 +71,22 @@ Template.medianResponseTime.onRendered(function () {
     // Get ElasticSearch aggregated data
     const elasticsearchData = Template.currentData().buckets;
 
-    // Get current timeframe
-    const dateCount = FlowRouter.getQueryParam('timeframe');
+    // Get query parameter value
+    const queryParamValue = FlowRouter.getQueryParam('timeframe');
+    // Get timeframe & granularity values
+    const [dateCount, granularity] = queryParamValue.split('-');
+
+    // Generate today date and just current hour
+    const today = moment().millisecond(0).second(0).minute(0);
 
     const params = {
-      // Date range must have equal length with dateCount value
-      // To include also today, subtract one day less than count of days in period
-      startDate: moment().subtract(dateCount - 1, 'd'),
-      endDate: moment(),
-      // Interval is 1 day
+      endDate: today.clone(),
+      startDate: today.subtract(dateCount - 1, granularity),
       step: 1,
+      granularity,
       // TODO: internationalize date formatting
       // https://github.com/apinf/platform/issues/2900
-      format: 'MM/DD',
+      format: granularity === 'hour' ? 'H:mm' : 'MM/DD',
     };
 
     const labels = generateDate(params);

--- a/apinf_packages/dashboard/client/view/overview/charts/requests_over_time/requests_over_time.js
+++ b/apinf_packages/dashboard/client/view/overview/charts/requests_over_time/requests_over_time.js
@@ -71,19 +71,22 @@ Template.requestsOverTime.onRendered(function () {
     // Get ElasticSearch aggregated data
     const elasticsearchData = Template.currentData().buckets;
 
-    // Get current timeframe
-    const dateCount = FlowRouter.getQueryParam('timeframe');
+    // Get timeframe query parameter
+    const queryParamValue = FlowRouter.getQueryParam('timeframe');
+    // Get timeframe & granularity values
+    const [dateCount, granularity] = queryParamValue.split('-');
+
+    // Generate today date and just current hour
+    const today = moment().millisecond(0).second(0).minute(0);
 
     const params = {
-      // Date range must have equal length with dateCount value
-      // Today value is included then subtract less days
-      startDate: moment().subtract(dateCount - 1, 'd'),
-      endDate: moment(),
-      // Interval is 1 day
+      endDate: today.clone(),
+      startDate: today.subtract(dateCount - 1, granularity),
       step: 1,
+      granularity,
       // TODO: internationalize date formatting
       // https://github.com/apinf/platform/issues/2900
-      format: 'MM/DD',
+      format: granularity === 'hour' ? 'H:mm' : 'MM/DD',
     };
 
     const labels = generateDate(params);

--- a/apinf_packages/dashboard/client/view/overview/charts/unique_users/unique_users.js
+++ b/apinf_packages/dashboard/client/view/overview/charts/unique_users/unique_users.js
@@ -71,19 +71,22 @@ Template.uniqueUsersOverTime.onRendered(function () {
     // Get ElasticSearch aggregated data
     const elasticsearchData = Template.currentData().buckets;
 
-    // Get current timeframe
-    const dateCount = FlowRouter.getQueryParam('timeframe');
+    // Get query parameter value
+    const queryParamValue = FlowRouter.getQueryParam('timeframe');
+    // Get timeframe & granularity values
+    const [dateCount, granularity] = queryParamValue.split('-');
+
+    // Generate today date and just current hour
+    const today = moment().millisecond(0).second(0).minute(0);
 
     const params = {
-      // Date range must have equal length with dateCount value
-      // To include also today, subtract one day less than count of days in period
-      startDate: moment().subtract(dateCount - 1, 'd'),
-      endDate: moment(),
-      // Interval is 1 day
+      endDate: today.clone(),
+      startDate: today.subtract(dateCount - 1, granularity),
       step: 1,
+      granularity,
       // TODO: internationalize date formatting
       // https://github.com/apinf/platform/issues/2900
-      format: 'MM/DD',
+      format: granularity === 'hour' ? 'H:mm' : 'MM/DD',
     };
 
     const labels = generateDate(params);

--- a/apinf_packages/dashboard/client/view/overview/overview.js
+++ b/apinf_packages/dashboard/client/view/overview/overview.js
@@ -16,6 +16,15 @@ import {
   summaryComparing,
 } from '/apinf_packages/dashboard/lib/trend_helpers';
 
+Template.dashboardOverviewStatistic.onCreated(function () {
+  this.autorun(() => {
+    // Get query parameter value
+    const queryParamValue = FlowRouter.getQueryParam('timeframe');
+    // Get timeframe value
+    this.timeframe = queryParamValue.split('-')[0];
+  });
+});
+
 Template.dashboardOverviewStatistic.helpers({
   arrowDirection (parameter) {
     // Provide compared data
@@ -26,17 +35,19 @@ Template.dashboardOverviewStatistic.helpers({
     return percentageValue(parameter, this);
   },
   overviewComparing (parameter) {
-    // Get value of timeframe
-    const currentTimeframe = FlowRouter.getQueryParam('timeframe');
+    const instance = Template.instance();
 
-    return summaryComparing(parameter, this, currentTimeframe);
+    return summaryComparing(parameter, this, instance.timeframe);
   },
   timeframeYesterday () {
-    const timeframe = FlowRouter.getQueryParam('timeframe');
+    const instance = Template.instance();
     // Because typeof timeframe is string
-    return timeframe === '1';
+    // TODO: Remake phrase "yesterday/last day" to "last 24 hour
+    return instance.timeframe === '24';
   },
   timeframe () {
-    return FlowRouter.getQueryParam('timeframe');
+    const instance = Template.instance();
+
+    return instance.timeframe;
   },
 });

--- a/apinf_packages/dashboard/client/view/query.js
+++ b/apinf_packages/dashboard/client/view/query.js
@@ -7,14 +7,13 @@
 // Npm packages imports
 import moment from 'moment';
 
-export default function queryForDashboardPage (proxyBackendPaths, timeframe) {
-  // Plus one day to include current day in selection
-  const today = moment().add(1, 'days').format('YYYY-MM-DD');
-
-  // Make it depends on timeframe
-  const oneTimePeriodAgo = moment().subtract(timeframe - 1, 'days').format('YYYY-MM-DD');
+export default function queryForDashboardPage (proxyBackendPaths, timeframe, interval) {
+  // Plus one granularity to include current day in selection
+  const today = moment().add(1, interval)._d.getTime();
+  // Make it depends on timeframe & interval
+  const oneTimePeriodAgo = moment().subtract(timeframe - 1, interval)._d.getTime();
   // eslint-disable-next-line no-mixed-operators
-  const twoTimePeriodsAgo = moment().subtract(2 * timeframe - 1, 'days').format('YYYY-MM-DD');
+  const twoTimePeriodsAgo = moment().subtract(2 * timeframe - 1, interval)._d.getTime();
 
   return {
     size: 0,
@@ -94,7 +93,7 @@ export default function queryForDashboardPage (proxyBackendPaths, timeframe) {
                 requests_over_time: {
                   date_histogram: {
                     field: 'request_at',
-                    interval: 'week',
+                    interval,
                   },
                   aggs: {
                     // Get the median response time over interval

--- a/apinf_packages/dashboard/client/view/view.js
+++ b/apinf_packages/dashboard/client/view/view.js
@@ -83,11 +83,14 @@ Template.dashboardView.onCreated(function () {
     if (elasticsearchHost) {
       // Get list of proxy backends paths
       const proxyBackendPaths = instance.proxyBackendPaths.get();
-      // Get timeframe
-      const timeframe = FlowRouter.getQueryParam('timeframe');
+
+      // Get query parameter
+      const queryParamValue = FlowRouter.getQueryParam('timeframe');
+      // Get values of timeframe & granularity
+      const [timeframe, granularity] = queryParamValue.split('-');
 
       // Make query object
-      const queryParams = queryForDashboardPage(proxyBackendPaths, timeframe);
+      const queryParams = queryForDashboardPage(proxyBackendPaths, timeframe, granularity);
 
       // Get chart data for dashboard
       Meteor.call('dashboardChartData', elasticsearchHost, queryParams, (error, result) => {

--- a/apinf_packages/dashboard/lib/trend_helpers.js
+++ b/apinf_packages/dashboard/lib/trend_helpers.js
@@ -110,7 +110,8 @@ export function summaryComparing (parameter, bucket, timeframe) {
     const params = { percentage: percentages, direction: trend, day: timeframe };
     // If comparison with 1 day then it is "yesterday"
     // typeof timeframe is string
-    if (timeframe === '1') {
+    // TODO: remake phrase "yesterday" to "last 24 hours"
+    if (timeframe === '24') {
       text = TAPi18n.__('summaryComparing_displayTrendInfo_yesterday', params);
     } else {
       text = TAPi18n.__('summaryComparing_displayTrendInfo_days', params);


### PR DESCRIPTION
Closes #3020 

## Changes
Describe your changes here as a bulleted list:
 - Update query parameter "timeframe". Now it has a format as "7-day" that contains timeframe value and granularity
 - When a user selects "Last 24 hours" that the charts have labels as "hour"

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @matleppa @mauriciovieira 

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
