### PR TITLE
Change fileNameEndsWith function: low case filename

### DIFF
--- a/apinf_packages/core/helper_functions/file_name_ends_with.js
+++ b/apinf_packages/core/helper_functions/file_name_ends_with.js
@@ -9,17 +9,20 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
     @param {array} suffixList - Array of file extension names e.g ['json', 'txt', 'yaml']
     */
 export default function fileNameEndsWith (filename, suffixList) {
-  // variable that keeps state of is this filename contains provided extensions - false by default
-  let state = false;
+  // Low case the filename
+  const filenameLowCase = filename.toLowerCase();
 
-  // iterating through extensions passed into suffixList array
+  // Iterating through extensions passed into suffixList array
   for (let i = 0; i < suffixList.length; i++) {
+    // Calculate index to start search
+    const fromIndex = filenameLowCase.length - suffixList[i].length;
     // parses line to check if filename contains current suffix
-    const endsWith = filename.indexOf(suffixList[i], filename.length - suffixList[i].length) !== -1;
+    const endsWith = filenameLowCase.indexOf(suffixList[i], fromIndex) !== -1;
 
-    // if current extension found in filename then change the state variable
-    if (endsWith) state = true;
+    // if current extension found in filename then return true
+    if (endsWith) return true;
   }
 
-  return state;
+  // Otherwise the extension isn't allowed
+  return false;
 }


### PR DESCRIPTION
Closes #3129

## Changes
- Low case a filename

## Steps for reproduce
1. `git checkout develop`
2. Go to Branding settings. Try to upload photo with JPG or JPEG extension. The upper case makes difference.
3. The expected result: a user can't upload photo
4. `git checkout bugfix/case-insensitive`
5. Repeat the 2 step
6. The expected result: the photo is uploaded

## Reviewer checklist
Reviewed by: @matleppa

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
