### PR TITLE
Return id of duplicate API in post api duplicate error

### DIFF
--- a/apinf_packages/apis/server/api.js
+++ b/apinf_packages/apis/server/api.js
@@ -400,10 +400,13 @@ CatalogV1.addCollection(Apis, {
         }
 
         // Check if API with same name already exists
-        if (Apis.findOne({ name: bodyParams.name })) {
-          return errorMessagePayload(400, 'Duplicate: API with same name already exists.');
-        }
+        const duplicateApi = Apis.findOne({ name: bodyParams.name });
 
+        if (duplicateApi) {
+          const detailLine = 'Duplicate: API with same name exists.';
+          const idValue = `${duplicateApi._id}`;
+          return errorMessagePayload(400, detailLine, 'id', idValue);
+        }
 
         // Description must not exceed field length in DB
         if (bodyParams.description) {

--- a/apinf_packages/rest_apis/server/rest_api_helpers.js
+++ b/apinf_packages/rest_apis/server/rest_api_helpers.js
@@ -4,7 +4,7 @@
  https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
 
  // Fill and return error response message body
- function errorMessagePayload (statusCode, messageText) {
+ function errorMessagePayload (statusCode, messageText, additionalKey, additionalValue) {
    // Fill payload
    const errorPayload = {
      statusCode,
@@ -13,6 +13,10 @@
        message: messageText,
      },
    };
+   // When an additional information is needed to be included in response
+   if (additionalKey) {
+     errorPayload.body[additionalKey] = additionalValue;
+   }
    return errorPayload;
  }
 


### PR DESCRIPTION
Closes #3268 

## Changes 
New functionality in REST APIs
- added possibility to display certain key and value in error response
- display duplicate API id in error response of Catalog API for POST /apis

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
