### PR TITLE
Feature/rest api several doc links

### DIFF
--- a/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
+++ b/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
@@ -75,13 +75,41 @@ const descriptionApis = {
   delete: `
   ### Deletes an API ###
 
-  Admin user or API manager can delete an identified API from the Catalog,
+  Admin user or API manager can delete an identified API from the Catalog.
 
   Example call:
 
     DELETE /apis/<API id>
 
   Result: deletes the API identified with <API id> and responds with HTTP code 204.
+
+  If match is not found, the operation is considered as failed.
+  `,
+  // --------------------------------------------
+  deleteDocumentation: `
+  ### Removes documentation of an API ###
+
+  Admin user or API manager can remove whole documentation or part of it of an identified API.
+  On success returns API object.
+
+  Example calls:
+
+    DELETE /apis/<API id>/documents
+
+  Result: Removes all documentation of the API identified with <API id>
+  and responds with HTTP code 200.
+
+
+    DELETE /apis/<API id>/documents?url=http://link-to-documentation
+
+  Result: Removes (if finds the match of) the mentioned documentation link of the API identified
+  with <API id> and responds with HTTP code 200.
+
+  Order of finding the match for the link
+  - openAPI documentation (documentationUrl)
+  - external documentation links
+
+  If match is not found, the operation is considered as failed.
   `,
 };
 

--- a/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
+++ b/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
@@ -47,11 +47,13 @@ const descriptionApis = {
 
 
   Parameters
-  * mandatory: name and url
-  * length of description must not exceed 1000 characters
-  * value of lifecycleStatus must be one of example list
-  * allowed values for parameter isPublic are "true" and "false"
-  * if isPublic is set false, only admin or manager can see the API
+  * mandatory: *name* and *url*
+  * length of *description* must not exceed 1000 characters
+  * value of *lifecycleStatus* must be one of example list
+  * allowed values for parameter *isPublic* are "true" and "false"
+    * if isPublic is set false, only admin or manager can see the API
+  * *documentationUrl* contains a http(s) link to OpenAPI (or Swagger) documentationUrl
+  * *externalDocument* contains a http(s) link for other types of documentation
   `,
   // --------------------------------------------
   put: `
@@ -61,10 +63,13 @@ const descriptionApis = {
   On success, returns the updated API object.
 
   Parameters
-  * length of description must not exceed 1000 characters
-  * value of lifecycleStatus must be one of example list
-  * allowed values for parameter isPublic are "true" and "false"
-  * if isPublic is set false, only admin or manager can see the API
+  * length of *description* must not exceed 1000 characters
+  * value of *lifecycleStatus* must be one of example list
+  * allowed values for parameter *isPublic* are "true" and "false"
+    * if isPublic is set false, only admin or manager can see the API
+  * *documentationUrl* contains a http(s) link to OpenAPI (or Swagger) documentationUrl
+  * *externalDocument* contains a http(s) link for other types of documentation
+
   `,
   // --------------------------------------------
   delete: `

--- a/apinf_packages/rest_apis/server/catalog.js
+++ b/apinf_packages/rest_apis/server/catalog.js
@@ -255,9 +255,12 @@ CatalogV1.swagger = {
           example: 'link-address-to-specification',
         },
         externalDocumentation: {
-          type: 'string',
+          type: 'array',
           description: 'A URL to an external site page with API documentation',
-          example: 'url-to-external-site',
+          items: {
+            type: 'string',
+            example: 'url-to-external-site',
+          },
         },
       },
     },

--- a/apinf_packages/rest_apis/server/catalog.js
+++ b/apinf_packages/rest_apis/server/catalog.js
@@ -121,6 +121,13 @@ CatalogV1.swagger = {
       format: 'int32',
       minimum: 0,
     },
+    url: {
+      name: 'url',
+      in: 'query',
+      description: 'Documentation link to be removed.',
+      required: false,
+      type: 'string',
+    },
   },
   definitions: {
     // The schema defining the type used for the body parameter in POST or PUT method


### PR DESCRIPTION
Closes #3220 

## Changes
- POST /apis and PUT /apis
  - external documentation links stored into array instead of one field
  - checking of update operation outcome is added
  - rollback in case tried to update both API object and documentation and update fails partially
- DELETE /apis/id/documents 
  - without query parameters the apiDoc document for API in question is removed
  - with query parameter (DELETE /apis/id/documents?url=<documentation-link>) the identified documentation link is removed
    - links are removed one at a time
    - matching link is removed, checking is started from openAPI document link, then external documentation links
  - 

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented

  