### PR TITLE
Travis to use container image for faster test performance.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
-sudo: required
-dist: trusty
-group: deprecated-2017Q4
+sudo: false
 
 language: node_js
 node_js:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,11 @@ services:
   - docker
 
 before_install:
+  - pwd
+  - ls -la
   # Install meteor locally on CI
-  - if [ ! -e "$HOME/.meteor/meteor" ]; then cat $HOME/.travis_install_meteor | sed s/--progress-bar/-sL/g | /bin/sh; fi
+  - if [ ! -e "$HOME/.meteor/meteor" ]; then cat .travis_install_meteor | sed s/--progress-bar/-sL/g | /bin/sh; fi
+
 
 before_script:
   - yarn


### PR DESCRIPTION
Two Travis CI related changes:

- Bugfix to "meteor not found" error blocking the automated tests.
- Switch to container image for the test environment to speed up the process (sudo: false).

No change to app functionality, no deeper review required. 