### PR TITLE
Remove possibility to add organisation managers by username

### DIFF
--- a/apinf_packages/organizations/client/managers/list/list.html
+++ b/apinf_packages/organizations/client/managers/list/list.html
@@ -7,8 +7,10 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
   <ul class="list-group">
     {{# each organizationManagers }}
       <li class="list-group-item">
-        {{ username }}
-        ({{ email }})
+      <!-- temporarily outcomment because of issue 3437 -->
+      <!--  {{ username }}
+        ({{ email }}) -->
+        {{ email }}
         <div class="pull-right">
           {{# unless emailVerified }}
             <span class="label label-default">

--- a/apinf_packages/organizations/server/methods.js
+++ b/apinf_packages/organizations/server/methods.js
@@ -74,7 +74,8 @@ Meteor.methods({
     const userByUsername = Accounts.findUserByUsername(manager.user);
 
     // "User" field can be e-mail value or username value
-    const user = userByEmail || userByUsername;
+    // temporarily only with email
+    const user = userByEmail /* || userByUsername */;
 
     // No matching in both direction
     if (!user) {


### PR DESCRIPTION
Closes #3437 

Temporary quick and dirty correction in Organization manager handling.

## Changes
- show only managers' email address, not username
- add manager only with email address, not with username

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project style guide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
