### PR TITLE
Use REST API to connect an API to a proxy

### DIFF
--- a/apinf_packages/apis/server/api.js
+++ b/apinf_packages/apis/server/api.js
@@ -1549,6 +1549,9 @@ CatalogV1.addRoute('apis/:id/proxyBackend', {
         return errorMessagePayload(400, 'The API must have a Proxy connection.');
       }
 
+      // store previous proxyBackend
+      const previousProxyBackend = proxyBackend;
+
       // _id and apiUmbrella id are not needed
       const proxyBackendId = proxyBackend._id;
       delete proxyBackend._id;
@@ -1782,6 +1785,57 @@ CatalogV1.addRoute('apis/:id/proxyBackend', {
           proxyBackend.apiUmbrella.settings.rate_limits.splice(removeIndex, 1);
           delete bodyParams.removeIndex;
         }
+
+        // Check if correct value is given for remove index
+        if (bodyParams.proxyId) {
+          // Want to connect to another proxy?
+          if (bodyParams.proxyId !== previousProxyBackend.proxyId) {
+            // Get proxy document
+            const proxy = Proxies.findOne(bodyParams.proxyId);
+
+            // proxy must exist
+            if (!proxy) {
+              return errorMessagePayload(404, 'Proxy with specified ID is not found.');
+            }
+
+            // proxy type must be apiUmbrella
+            if (proxy.type !== 'apiUmbrella' ) {
+              return errorMessagePayload(404, 'New proxy is wrong type.', 'Type', proxy.type);
+            }
+            // Delete info about old proxy from apiUmbrella
+            const deleteResponse = Meteor.call('deleteProxyBackend',
+                                                previousProxyBackend, false);
+            if (deleteResponse) {
+              return errorMessagePayload(500, "Remove proxy backend failed on apiUmbrella",
+                                         "response", deleteResponse);
+            }
+
+            // Remove old apiUmbrellaId
+            delete proxyBackend.apiUmbrella.id;
+
+            // Insert corresponding proxy backend to apiUmbrella
+            const response = Meteor.call('createApiBackendOnApiUmbrella',
+              proxyBackend.apiUmbrella,
+              proxyBackend.proxyId);
+
+            // If response has errors object, notify about it
+            if (response.errors && response.errors.default) {
+              // Notify about error
+              return errorMessagePayload(500, "Adding a backend on apiUmbrella failed",
+                                         "Response", response.errors.default[0]);
+            }
+
+            // Get the API Umbrella ID for newly created backend
+            const newUmbrellaBackendId = response.result.data.api.id;
+
+            // Attach the API Umbrella backend ID to backend document
+            proxyBackend.apiUmbrella.id = newUmbrellaBackendId;
+            proxyBackend.proxyId = bodyParams.proxyId;
+
+          }
+          delete bodyParams.proxyId;
+        }
+
       } else {
         return errorMessagePayload(400, 'Unknown proxy type.');
       }

--- a/apinf_packages/apis/server/api.js
+++ b/apinf_packages/apis/server/api.js
@@ -1,4 +1,4 @@
-/* Copyright 2017 Apinf Oy
+/* Copyright 2018 Apinf Oy
  This file is covered by the EUPL license.
  You may obtain a copy of the licence at
  https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
@@ -10,12 +10,19 @@ import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/alanning:roles';
 import { SimpleSchema } from 'meteor/aldeed:simple-schema';
 
+// Npm packages imports
+import URI from 'urijs';
+import _ from 'lodash';
+
 // Collection imports
 import Apis from '/apinf_packages/apis/collection';
 import ApiDocs from '/apinf_packages/api_docs/collection';
+import Proxies from '/apinf_packages/proxies/collection';
 import ProxyBackends from '/apinf_packages/proxy_backends/collection';
 
 // APInf imports
+import { proxyBasePathRegEx,
+         apiBasePathRegEx } from '/apinf_packages/proxy_backends/collection/regex';
 import CatalogV1 from '/apinf_packages/rest_apis/server/catalog';
 import Organizations from '/apinf_packages/organizations/collection';
 import Authentication from '/apinf_packages/rest_apis/server/authentication';
@@ -33,7 +40,7 @@ CatalogV1.addCollection(Apis, {
     authRequired: false,
   },
   endpoints: {
-    // Response contains a list of all public entities within the collection
+    // Show information of all APIs
     getAll: {
       swagger: {
         tags: [
@@ -57,7 +64,7 @@ CatalogV1.addCollection(Apis, {
               properties: {
                 status: {
                   type: 'string',
-                  example: 'Success',
+                  example: 'success',
                 },
                 data: {
                   type: 'array',
@@ -190,6 +197,19 @@ CatalogV1.addCollection(Apis, {
             const proxyUrl = proxyBackend.proxyUrl();
             // Get proxy backend path
             const frontendPrefix = proxyBackend.frontendPrefix();
+
+            // Admin can see also actual API URL
+            if (requestorIsAdmin) {
+              api.backendURL = api.url;
+              api.backendPrefix = proxyBackend.backendPrefix();
+              // Get name and type of proxy
+              const proxy = Proxies.findOne(proxyBackend.proxyId);
+              if (proxy) {
+                api.proxyName = proxy.name;
+                api.proxyType = proxy.type;
+              }
+            }
+
             // Provide full proxy path
             api.url = proxyUrl.concat(frontendPrefix);
           }
@@ -212,7 +232,7 @@ CatalogV1.addCollection(Apis, {
         };
       },
     },
-    // Response contains the entity with the given :id
+    // Show information of an identified API
     get: {
       authRequired: false,
       swagger: {
@@ -258,20 +278,22 @@ CatalogV1.addCollection(Apis, {
           return errorMessagePayload(404, 'API with specified ID is not found.');
         }
 
+        // Check if user is Admin or Manager
+        let userCanManage = false;
+        // Get requestor ID from header
+        const requestorId = this.request.headers['x-user-id'];
+
+        if (requestorId) {
+          // Check if requestor is administrator
+          const requestorIsAdmin = Roles.userIsInRole(requestorId, ['admin']);
+          // Check if requestor is manager
+          const requestorIsManager = api.currentUserCanManage(requestorId);
+          userCanManage = requestorIsAdmin || requestorIsManager;
+        }
+
         // Only Public APIs are available for non-admin/non-manager user
         if (api.isPublic === false) {
-          let displayPrivateAPI = false;
-          // Get requestor ID from header
-          const requestorId = this.request.headers['x-user-id'];
-
-          if (requestorId) {
-            // Check if requestor is administrator
-            const requestorIsAdmin = Roles.userIsInRole(requestorId, ['admin']);
-            // Check if requestor is manager
-            const requestorIsManager = api.currentUserCanManage(requestorId);
-            displayPrivateAPI = requestorIsAdmin || requestorIsManager;
-          }
-          if (!displayPrivateAPI) {
+          if (!userCanManage) {
             return {
               statusCode: 204,
               body: {
@@ -295,6 +317,20 @@ CatalogV1.addCollection(Apis, {
           const proxyUrl = proxyBackend.proxyUrl();
           // Get proxy backend path
           const frontendPrefix = proxyBackend.frontendPrefix();
+
+          // Manager can see also actual API URL
+          if (userCanManage) {
+            api.backendURL = api.url;
+            api.backendPrefix = proxyBackend.backendPrefix();
+
+            // Get name and type of proxy
+            const proxy = Proxies.findOne(proxyBackend.proxyId);
+            if (proxy) {
+              api.proxyName = proxy.name;
+              api.proxyType = proxy.type;
+            }
+          }
+
           // Provide full proxy path
           api.url = proxyUrl.concat(frontendPrefix);
         }
@@ -334,7 +370,7 @@ CatalogV1.addCollection(Apis, {
               properties: {
                 status: {
                   type: 'string',
-                  example: 'Success',
+                  example: 'success',
                 },
                 data: {
                   $ref: '#/definitions/apiResponse',
@@ -518,7 +554,7 @@ CatalogV1.addCollection(Apis, {
         };
       },
     },
-    // Modify the entity with the given :id with the data contained in the request body.
+    // Modify identified API
     put: {
       authRequired: true,
       // manager role is required. If a user already has an API then the user has manager role
@@ -541,7 +577,7 @@ CatalogV1.addCollection(Apis, {
               properties: {
                 status: {
                   type: 'string',
-                  example: 'Success',
+                  example: 'success',
                 },
                 data: {
                   $ref: '#/definitions/apiResponse',
@@ -655,7 +691,7 @@ CatalogV1.addCollection(Apis, {
         }
         // Check if link for openAPI documentation was given
         const documentationUrl = bodyParams.documentationUrl;
-        // Cehck if link for external documentation was given
+        // Check if link for external documentation was given
         const externalDocumentation = bodyParams.externalDocumentation;
 
         if (documentationUrl || externalDocumentation) {
@@ -776,6 +812,31 @@ CatalogV1.addCollection(Apis, {
             documentationUrl: api.documentationUrl(),
           });
 
+
+        // Instead of API URL, return API Proxy's URL, if it exists
+        const proxyBackend = ProxyBackends.findOne({ apiId: api._id });
+
+        // If Proxy is API Umbrella, fill in proxy URL
+        if (proxyBackend && proxyBackend.type === 'apiUmbrella') {
+          // Get connected proxy url
+          const proxyUrl = proxyBackend.proxyUrl();
+          // Get proxy backend path
+          const frontendPrefix = proxyBackend.frontendPrefix();
+          // Display also actual API URL
+          responseData.backendURL = responseData.url;
+          responseData.backendPrefix = proxyBackend.backendPrefix();
+
+          // Get name of proxy
+          const proxy = Proxies.findOne(proxyBackend.proxyId);
+          if (proxy) {
+            responseData.proxyName = proxy.name;
+            responseData.proxyType = proxy.type;
+          }
+
+          // Provide full proxy path
+          responseData.url = proxyUrl.concat(frontendPrefix);
+        }
+
         // OK response with API data
         return {
           statusCode: 200,
@@ -855,7 +916,6 @@ CatalogV1.addCollection(Apis, {
     },
   },
 });
-
 
 // Request /rest/v1/apis/:id/documents/
 CatalogV1.addRoute('apis/:id/documents', {
@@ -995,4 +1055,846 @@ CatalogV1.addRoute('apis/:id/documents', {
       };
     },
   },
+});
+
+// Request /rest/v1/apis/:id/proxyBackend/
+CatalogV1.addRoute('apis/:id/proxyBackend', {
+  // Show information of API's proxy connection
+  get: {
+    authRequired: true,
+    swagger: {
+      tags: [
+        CatalogV1.swagger.tags.api,
+      ],
+      summary: 'Show Proxy connection of an API.',
+      description: descriptionApis.getProxyBackend,
+      parameters: [
+        CatalogV1.swagger.params.apiId,
+      ],
+      responses: {
+        200: {
+          description: 'Proxy connection exists for this API',
+          schema: {
+            type: 'object',
+            properties: {
+              status: {
+                type: 'string',
+                example: 'Success',
+              },
+              data: {
+                $ref: '#/definitions/proxyConnectionResponse',
+              },
+            },
+          },
+        },
+        400: {
+          description: 'Bad Request. Erroneous or missing parameter.',
+        },
+        401: {
+          description: 'Authentication is required',
+        },
+        403: {
+          description: 'User does not have permission',
+        },
+        404: {
+          description: 'API is not found',
+        },
+      },
+      security: [
+        {
+          userSecurityToken: [],
+          userId: [],
+        },
+      ],
+    },
+    action () {
+      // Get ID of API (URL parameter)
+      const apiId = this.urlParams.id;
+      // Get User ID
+      const userId = this.userId;
+
+      // API related checkings
+      // Get API document
+      const api = Apis.findOne(apiId);
+
+      // API must exist
+      if (!api) {
+        // API doesn't exist
+        return errorMessagePayload(404, 'API with specified ID is not found.');
+      }
+
+      // User must be able to manage API
+      if (!api.currentUserCanManage(userId)) {
+        return errorMessagePayload(403, 'User does not have permission to this API.');
+      }
+
+      // Get API's Proxy connection data
+      const proxyBackend = ProxyBackends.findOne({ apiId });
+      if (!proxyBackend) {
+        // The Proxy backend doesn't exist
+        return errorMessagePayload(404, 'Proxy connection for the API is not found.');
+      }
+
+      // OK response with Proxy backend data
+      return {
+        statusCode: 200,
+        body: {
+          status: 'success',
+          data: proxyBackend,
+        },
+      };
+    },
+  },
+  // Connect given API to a given proxy
+  post: {
+    authRequired: true,
+    swagger: {
+      tags: [
+        CatalogV1.swagger.tags.api,
+      ],
+      summary: 'Connect an API to a proxy.',
+      description: descriptionApis.postProxyBackend,
+      parameters: [
+        CatalogV1.swagger.params.apiId,
+        CatalogV1.swagger.params.proxyConnectionRequestPost,
+      ],
+      responses: {
+        200: {
+          description: 'API connected to a Proxy successfully',
+          schema: {
+            type: 'object',
+            properties: {
+              status: {
+                type: 'string',
+                example: 'Success',
+              },
+              data: {
+                $ref: '#/definitions/proxyConnectionResponse',
+              },
+            },
+          },
+        },
+        400: {
+          description: 'Bad Request. Erroneous or missing parameter.',
+        },
+        401: {
+          description: 'Authentication is required',
+        },
+        403: {
+          description: 'User does not have permission',
+        },
+        404: {
+          description: 'API is not found',
+        },
+      },
+      security: [
+        {
+          userSecurityToken: [],
+          userId: [],
+        },
+      ],
+    },
+    action () {
+      // Get ID of API (URL parameter)
+      const apiId = this.urlParams.id;
+      // Get User ID
+      const userId = this.userId;
+
+      // API related checkings
+      // Get API document
+      const api = Apis.findOne(apiId);
+
+      // API must exist
+      if (!api) {
+        // API doesn't exist
+        return errorMessagePayload(404, 'API with specified ID is not found.');
+      }
+
+      // User must be able to manage API
+      if (!api.currentUserCanManage(userId)) {
+        return errorMessagePayload(403, 'User does not have permission to this API.');
+      }
+
+      // Check if the API is already connected to a Proxy
+      const existingProxyBackend = ProxyBackends.findOne({ apiId });
+      if (existingProxyBackend) {
+        // The Proxy backend already exist
+        return errorMessagePayload(400, 'Proxy connection for the API already exist.');
+      }
+
+      // Get body parameters
+      const bodyParams = this.bodyParams;
+      // At least one parameter has to be given
+      if (!Object.keys(bodyParams).length) {
+        return errorMessagePayload(400, 'No parameters given.');
+      }
+
+      // Proxy related checkings
+      // proxyId is a required field
+      if (!bodyParams.proxyId) {
+        return errorMessagePayload(400, 'Parameter "proxyId" is mandatory.');
+      }
+
+      // Get proxy document
+      const proxy = Proxies.findOne(bodyParams.proxyId);
+
+      // proxy must exist
+      if (!proxy) {
+        return errorMessagePayload(404, 'Proxy with specified ID is not found.');
+      }
+
+      // Collect data to be inserted into proxyBackend
+      const newProxyBackendData = {
+        apiId,
+        proxyId: proxy._id,
+        // Type comes from selected proxy
+        type: proxy.type,
+      };
+
+      if (proxy.type === 'apiUmbrella') {
+        // frontendPrefix is a required field
+        if (!bodyParams.frontendPrefix) {
+          return errorMessagePayload(400, 'Parameter "frontendPrefix" is mandatory.');
+        }
+
+        // Validation of frontendPrefix
+        if (!proxyBasePathRegEx.test(bodyParams.frontendPrefix)) {
+          return errorMessagePayload(400, 'Parameter "frontendPrefix" not valid.',
+          'frontendPrefix', bodyParams.frontendPrefix);
+        }
+
+        // Check if given frontend_prefix is already in use
+        const duplicateFEPrefix = ProxyBackends.findOne({
+          'apiUmbrella.url_matches.frontend_prefix': bodyParams.frontendPrefix,
+        });
+        if (duplicateFEPrefix) {
+          return errorMessagePayload(400, 'Parameter "frontendPrefix" must be unique.');
+        }
+
+        const frontendPrefix = bodyParams.frontendPrefix;
+
+        // backendPrefix is a required field
+        if (!bodyParams.backendPrefix) {
+          return errorMessagePayload(400, 'Parameter "backendPrefix" is mandatory.');
+        }
+
+        // Validation of backendPrefix
+        if (!apiBasePathRegEx.test(bodyParams.backendPrefix)) {
+          return errorMessagePayload(400, 'Parameter "backendPrefix" not valid.',
+          'backendPrefix', bodyParams.backendPrefix);
+        }
+        const backendPrefix = bodyParams.backendPrefix;
+
+        // Collect prefixes
+        const urlMatches = [{
+          frontend_prefix: frontendPrefix,
+          backend_prefix: backendPrefix,
+        }];
+
+        // Prepare apiUmbrella object
+        const apiUmbrella = {};
+
+        // Get API details from API document
+        apiUmbrella.name = api.name;
+
+        // Frontend host address comes from proxy document
+        const apiUmbrellaUrl = new URI(proxy.apiUmbrella.url);
+        apiUmbrella.frontend_host = apiUmbrellaUrl.host();
+
+        // Backend host address comes from API
+        const apiUrl = new URI(api.url);
+        apiUmbrella.backend_host = apiUrl.host();
+        apiUmbrella.backend_protocol = apiUrl.protocol();
+
+        // Information of server address and port
+        // By default apiPort is set to 443 for https
+        let apiPort = 443;
+        // Default apiPort for https is 80
+        if (apiUmbrella.backend_protocol === 'http') {
+          apiPort = 80;
+        }
+        // apiPort must be a numeric value
+        if (bodyParams.apiPort) {
+          if (isNaN(bodyParams.apiPort) || bodyParams.apiPort < 0 || bodyParams.apiPort > 65535) {
+            return errorMessagePayload(400, 'Parameter "apiPort" has erroneous value.',
+            'apiPort', bodyParams.apiPort);
+          }
+          apiPort = bodyParams.apiPort;
+        }
+
+        const servers = [{
+          host: apiUrl.host(),
+          port: apiPort,
+        }];
+
+        // Prepare and fill settings object
+        const settings = {};
+
+        // If disableApiKey is given, it can be only literal true/false
+        if (bodyParams.disableApiKey) {
+          const allowedDisableApiKeyValues = ['false', 'true'];
+          if (!allowedDisableApiKeyValues.includes(bodyParams.disableApiKey)) {
+            return errorMessagePayload(400, 'Parameter "disableApiKey" has erroneous value.',
+            'disableApiKey', bodyParams.disableApiKey);
+          }
+        }
+
+        // Convert given value to boolean. Also sets default false, if value not given.
+        settings.disable_api_key = (bodyParams.disableApiKey === 'true');
+
+        // Rate limit modes, default value is unlimited
+        settings.rate_limit_mode = bodyParams.rateLimitMode || 'unlimited';
+        const allowedRateLimitModeValues = ['custom', 'unlimited'];
+
+        // Is Rate limit mode allowed value
+        if (!allowedRateLimitModeValues.includes(settings.rate_limit_mode)) {
+          return errorMessagePayload(400, 'Parameter "rateLimitMode" has erroneous value.',
+          'rateLimitMode', bodyParams.rateLimitMode);
+        }
+
+        // When rate_limit_mode is 'custom', also additional parameters can be given
+        if (settings.rate_limit_mode === 'custom') {
+          // duration must be a numeric value
+          if (bodyParams.duration) {
+            if (isNaN(bodyParams.duration) || bodyParams.duration < 0) {
+              return errorMessagePayload(400, 'Parameter "duration" has erroneous value.',
+              'duration', bodyParams.duration);
+            }
+          }
+
+          // Is limitBy allowed value
+          if (bodyParams.limitBy) {
+            const allowedRateLimitByValues = ['apiKey', 'ip'];
+            if (!allowedRateLimitByValues.includes(bodyParams.limitBy)) {
+              return errorMessagePayload(400, 'Parameter "limitBy" has erroneous value.',
+              'limitBy', bodyParams.limitBy);
+            }
+          }
+
+          // limit must be a numeric value
+          if (bodyParams.limit) {
+            if (isNaN(bodyParams.limit) || bodyParams.limit < 0) {
+              return errorMessagePayload(400, 'Parameter "limit" has erroneous value.',
+              'limit', bodyParams.limit);
+            }
+          }
+
+          // If disableApiKey is given, it can be only literal true/false
+          if (bodyParams.showLimit) {
+            const allowedshowLimitValues = ['false', 'true'];
+            if (!allowedshowLimitValues.includes(bodyParams.showLimit)) {
+              return errorMessagePayload(400, 'Parameter "showLimit" has erroneous value.',
+              'showLimit', bodyParams.showLimit);
+            }
+          }
+
+          // Convert given value to boolean. Also sets default false, if value not given.
+          const showLimitInResponseHeaders = (bodyParams.showLimit === 'true');
+
+          // Get given values ready for DB write
+          const rateLimits = [{
+            duration: bodyParams.duration * 1,
+            limit_by: bodyParams.limitBy,
+            limit: bodyParams.limit * 1,
+            response_headers: showLimitInResponseHeaders,
+          }];
+          // Add into settings
+          settings.rate_limits = rateLimits;
+        }
+
+        // Collect apiUmbrella related data
+        apiUmbrella.balance_algorithm = 'least_conn';
+        apiUmbrella.servers = servers;
+        apiUmbrella.url_matches = urlMatches;
+        apiUmbrella.settings = settings;
+
+        // Fill the new backend data
+        newProxyBackendData.apiUmbrella = apiUmbrella;
+
+        // Insert corresponding proxy backend to apiUmbrella
+        const response = Meteor.call('createApiBackendOnApiUmbrella',
+          newProxyBackendData.apiUmbrella,
+          newProxyBackendData.proxyId);
+
+        // If response has errors object, notify about it
+        if (response.errors && response.errors.default) {
+          // Notify about error
+          return errorMessagePayload(500, response.errors.default[0]);
+        }
+
+        // If success, attach API Umbrella backend ID to API
+        if (!_.has(response, 'result.data.api')) {
+          return errorMessagePayload(500, 'apiUmbrella update failed.');
+        }
+        // Get the API Umbrella ID for newly created backend
+        const umbrellaBackendId = response.result.data.api.id;
+
+        // Attach the API Umbrella backend ID to backend document
+        newProxyBackendData.apiUmbrella.id = umbrellaBackendId;
+
+          // Publish the API Backend on API Umbrella
+        const publishSuccess = Meteor.call('publishApiBackendOnApiUmbrella',
+                      umbrellaBackendId, newProxyBackendData.proxyId);
+        if (publishSuccess.errors && response.errors.default) {
+          return errorMessagePayload(publishSuccess.errors.http_status,
+            publishSuccess.errors.default);
+        }
+
+        // Insert the apiUmbrella Proxy Backend document on APInf
+        const proxyBackendId = ProxyBackends.insert(newProxyBackendData);
+        if (!proxyBackendId) {
+          return errorMessagePayload(500, 'Creating proxyBackend failed.');
+        }
+
+        // Start cron tasks that run storing Analytics Data to MongoDB
+        Meteor.call('calculateAnalyticsData', proxyBackendId);
+
+        // Create a placeholder in 30 days for charts for particular Proxy Backend
+        Meteor.call('proxyBackendAnalyticsData', proxyBackendId, 30, 'today');
+      } else {
+        return errorMessagePayload(400, 'Unknown proxy type.');
+      }
+
+      // Get API's just inserted Proxy connection data for response
+      const createdProxyBackend = ProxyBackends.findOne({ apiId });
+      if (!createdProxyBackend) {
+        // The Proxy backend doesn't exist
+        return errorMessagePayload(500, 'Proxy connection for the API is not created.');
+      }
+
+      // Send OK response with API data
+      return {
+        statusCode: 200,
+        body: {
+          status: 'success',
+          data: createdProxyBackend,
+        },
+      };
+    },
+  },
+  // Modify proxy backend parameters of given API
+  put: {
+    authRequired: true,
+    swagger: {
+      tags: [
+        CatalogV1.swagger.tags.api,
+      ],
+      summary: 'Modify Proxy connection parameters of an API.',
+      description: descriptionApis.putProxyBackend,
+      parameters: [
+        CatalogV1.swagger.params.apiId,
+        CatalogV1.swagger.params.proxyConnectionRequestPut,
+      ],
+      responses: {
+        200: {
+          description: 'Proxy connection parameters modified successfully',
+          schema: {
+            type: 'object',
+            properties: {
+              status: {
+                type: 'string',
+                example: 'Success',
+              },
+              data: {
+                $ref: '#/definitions/proxyConnectionResponse',
+              },
+            },
+          },
+        },
+        400: {
+          description: 'Bad Request. Erroneous or missing parameter.',
+        },
+        401: {
+          description: 'Authentication is required',
+        },
+        403: {
+          description: 'User does not have permission',
+        },
+        404: {
+          description: 'API is not found',
+        },
+      },
+      security: [
+        {
+          userSecurityToken: [],
+          userId: [],
+        },
+      ],
+    },
+    action () {
+      // Get ID of API (URL parameter)
+      const apiId = this.urlParams.id;
+      // Get User ID
+      const userId = this.userId;
+
+      // API related checkings
+      // Get API document
+      const api = Apis.findOne(apiId);
+
+      // API must exist
+      if (!api) {
+        // API doesn't exist
+        return errorMessagePayload(404, 'API with specified ID is not found.');
+      }
+
+      // User must be able to manage API
+      if (!api.currentUserCanManage(userId)) {
+        return errorMessagePayload(403, 'User does not have permission to this API.');
+      }
+
+      // Check if the API is connected to a Proxy
+      const proxyBackend = ProxyBackends.findOne({ apiId });
+      if (!proxyBackend) {
+        // The Proxy backend must exist
+        return errorMessagePayload(400, 'The API must have a Proxy connection.');
+      }
+
+      // _id and apiUmbrella id are not needed
+      const proxyBackendId = proxyBackend._id;
+      delete proxyBackend._id;
+      delete proxyBackend.apiUmbrella.id;
+
+      // Get proxy document
+      const proxy = Proxies.findOne(proxyBackend.proxyId);
+
+      // proxy must exist
+      if (!proxy) {
+        return errorMessagePayload(404, 'Proxy with specified ID is not found.');
+      }
+
+      // Get body parameters
+      const bodyParams = this.bodyParams;
+
+      // At least one parameter has to be given
+      if (!Object.keys(bodyParams).length) {
+        return errorMessagePayload(400, 'No parameters given.');
+      }
+
+      // For simplicity: either edit or remove at a time
+      if (bodyParams.editIndex && bodyParams.removeIndex) {
+        return errorMessagePayload(400, 'Only editIndex or removeIndex can be given at a time.');
+      }
+
+      // Functionality related to proxy type
+      //           apiUmbrella
+      // -----------------------------------
+      if (proxyBackend.type === 'apiUmbrella') {
+        // No changes to emq part here
+        delete proxyBackend.emq;
+
+        // is frontendPrefix given
+        if (bodyParams.frontendPrefix) {
+          // Validation of frontendPrefix
+          if (!proxyBasePathRegEx.test(bodyParams.frontendPrefix)) {
+            return errorMessagePayload(400, 'Parameter "frontendPrefix" not valid.',
+            'frontendPrefix', bodyParams.frontendPrefix);
+          }
+          // Check if given frontend_prefix is already in use
+          const duplicateFEPrefix = ProxyBackends.findOne({
+            'apiUmbrella.url_matches.frontend_prefix': bodyParams.frontendPrefix,
+          });
+          if (duplicateFEPrefix) {
+            return errorMessagePayload(400, 'Parameter "frontendPrefix" must be unique.');
+          }
+          proxyBackend.apiUmbrella.url_matches[0].frontend_prefix = bodyParams.frontendPrefix;
+          delete bodyParams.frontendPrefix;
+        }
+
+        // is backendPrefix given
+        if (bodyParams.backendPrefix) {
+          // Validation of backendPrefix
+          if (!apiBasePathRegEx.test(bodyParams.backendPrefix)) {
+            return errorMessagePayload(400, 'Parameter "backendPrefix" not valid.',
+            'backendPrefix', bodyParams.backendPrefix);
+          }
+          proxyBackend.apiUmbrella.url_matches[0].backend_prefix = bodyParams.backendPrefix;
+          delete bodyParams.backendPrefix;
+        }
+
+        // Get API details from API document
+        proxyBackend.apiUmbrella.name = api.name;
+
+        // Frontend host address comes from proxy document
+        const apiUmbrellaUrl = new URI(proxy.apiUmbrella.url);
+        proxyBackend.apiUmbrella.frontend_host = apiUmbrellaUrl.host();
+
+        // Backend host address comes from API
+        const apiUrl = new URI(api.url);
+        proxyBackend.apiUmbrella.backend_host = apiUrl.host();
+        proxyBackend.apiUmbrella.backend_protocol = apiUrl.protocol();
+
+        // apiPort must be a numeric value
+        if (bodyParams.apiPort) {
+          if (isNaN(bodyParams.apiPort) || bodyParams.apiPort < 0 || bodyParams.apiPort > 65535) {
+            return errorMessagePayload(400, 'Parameter "apiPort" has erroneous value.',
+            'apiPort', bodyParams.apiPort);
+          }
+          proxyBackend.apiUmbrella.servers[0].port = 1 * bodyParams.apiPort;
+          delete bodyParams.apiPort;
+        }
+        proxyBackend.apiUmbrella.servers[0].host = apiUrl.host();
+
+        // If disableApiKey is given, it can be only literal true/false
+        if (bodyParams.disableApiKey) {
+          const allowedDisableApiKeyValues = ['false', 'true'];
+          if (!allowedDisableApiKeyValues.includes(bodyParams.disableApiKey)) {
+            return errorMessagePayload(400, 'Parameter "disableApiKey" has erroneous value.',
+            'disableApiKey', bodyParams.disableApiKey);
+          }
+          // Convert given value to boolean. Also sets default false, if value not given.
+          proxyBackend.apiUmbrella.settings.disable_api_key = (bodyParams.disableApiKey === 'true');
+          delete bodyParams.disableApiKey;
+        }
+
+        // Is rateLimitMode given with correct value
+        if (bodyParams.rateLimitMode) {
+          const allowedRateLimitModeValues = ['custom', 'unlimited'];
+          // Is Rate limit mode allowed value
+          if (!allowedRateLimitModeValues.includes(bodyParams.rateLimitMode)) {
+            return errorMessagePayload(400, 'Parameter "rateLimitMode" has erroneous value.',
+            'rateLimitMode', bodyParams.rateLimitMode);
+          }
+          proxyBackend.apiUmbrella.settings.rate_limit_mode = bodyParams.rateLimitMode;
+          delete bodyParams.rateLimitMode;
+        }
+
+        // In case rate limits are modified, also index to point to changed object is needed
+        if (bodyParams.editIndex) {
+          if (!bodyParams.duration &&
+              !bodyParams.limitBy &&
+              !bodyParams.limit &&
+              !bodyParams.showLimit) {
+            return errorMessagePayload(400, 'At least one rate parameter needed with editIndex');
+          }
+        }
+
+        if (!bodyParams.editIndex) {
+          if (bodyParams.duration ||
+              bodyParams.limitBy ||
+              bodyParams.limit ||
+              bodyParams.showLimit) {
+            return errorMessagePayload(400, 'editIndex is needed with rate parameters');
+          }
+        }
+        // Count number of rate limits currently in DB
+        let countOfRates = 0;
+        if (proxyBackend.apiUmbrella.settings.rate_limits) {
+          countOfRates = proxyBackend.apiUmbrella.settings.rate_limits.length;
+        }
+
+        // Is the editIndex given
+        if (bodyParams.editIndex) {
+          // Rate limits can be modified only in case rate limit mode is 'custom'
+          if (proxyBackend.apiUmbrella.settings.rate_limit_mode !== 'custom') {
+            return errorMessagePayload(400, 'Rate parameters allowed only when mode is custom');
+          }
+
+          // Prepare index
+          const rlIndex = 1 * bodyParams.editIndex;
+
+          // Does the rate limit index have correct value
+          if (isNaN(rlIndex) || rlIndex < 0 || rlIndex > countOfRates) {
+            const detailLine = `Allowed range for 'editIndex' is 0 - ${countOfRates}`;
+            return errorMessagePayload(400, detailLine, 'editIndex', rlIndex);
+          }
+
+          // Prepare rate_limits object
+          let rateLimits = {};
+          // if the rate limits object exists, it is used as a basis
+          if (proxyBackend.apiUmbrella.settings.rate_limits[rlIndex]) {
+            rateLimits = proxyBackend.apiUmbrella.settings.rate_limits[rlIndex];
+          } else if (!bodyParams.duration ||
+                     !bodyParams.limitBy ||
+                     !bodyParams.limit ||
+                     !bodyParams.showLimit) {
+            const detailLine = 'All rate parameters needed when adding a new rate set';
+            return errorMessagePayload(400, detailLine);
+          }
+
+          // duration must be a numeric value
+          if (bodyParams.duration) {
+            if (isNaN(bodyParams.duration) || bodyParams.duration < 0) {
+              return errorMessagePayload(400, 'Parameter "duration" has erroneous value.',
+              'duration', bodyParams.duration);
+            }
+            rateLimits.duration = bodyParams.duration * 1;
+            delete bodyParams.duration;
+          }
+
+          // Is limitBy allowed value
+          if (bodyParams.limitBy) {
+            const allowedRateLimitByValues = ['apiKey', 'ip'];
+            if (!allowedRateLimitByValues.includes(bodyParams.limitBy)) {
+              return errorMessagePayload(400, 'Parameter "limitBy" has erroneous value.',
+              'limitBy', bodyParams.limitBy);
+            }
+            rateLimits.limit_by = bodyParams.limitBy;
+            delete bodyParams.limitBy;
+          }
+
+          // limit must be a numeric value
+          if (bodyParams.limit) {
+            if (isNaN(bodyParams.limit) || bodyParams.limit < 0) {
+              return errorMessagePayload(400, 'Parameter "limit" has erroneous value.',
+              'limit', bodyParams.limit);
+            }
+            rateLimits.limit = 1 * bodyParams.limit;
+            delete bodyParams.limit;
+          }
+
+          // If disableApiKey is given, it can be only literal true/false
+          if (bodyParams.showLimit) {
+            const allowedshowLimitValues = ['false', 'true'];
+            if (!allowedshowLimitValues.includes(bodyParams.showLimit)) {
+              return errorMessagePayload(400, 'Parameter "showLimit" has erroneous value.',
+              'showLimit', bodyParams.showLimit);
+            }
+            // Convert given value to boolean. Also sets default false, if value not given.
+            rateLimits.response_headers = (bodyParams.showLimit === 'true');
+            delete bodyParams.showLimit;
+          }
+
+          proxyBackend.apiUmbrella.settings.rate_limits[rlIndex] = rateLimits;
+          delete bodyParams.editIndex;
+        }
+
+        // Check if correct value is given for remove index
+        if (bodyParams.removeIndex) {
+          // Rate limits can be removed only in case rate limit mode is 'custom'
+          if (proxyBackend.apiUmbrella.settings.rate_limit_mode !== 'custom') {
+            return errorMessagePayload(400, 'Rate set removal allowed only when mode is custom');
+          }
+
+          // Prepare index
+          const removeIndex = 1 * bodyParams.removeIndex;
+
+          // Does the rate limit remove index have correct value
+          if (isNaN(removeIndex) || removeIndex < 0 || removeIndex > countOfRates) {
+            const detailLine = `Allowed range for 'removeIndex' is 0 - ${countOfRates - 1}`;
+            return errorMessagePayload(400, detailLine, 'removeIndex', removeIndex);
+          }
+          // find the rate limits object
+          if (!proxyBackend.apiUmbrella.settings.rate_limits[removeIndex]) {
+            const detailLine = 'Rate limit object does not exist';
+            return errorMessagePayload(400, detailLine);
+          }
+
+          // Remove the indicated rate limit object
+          proxyBackend.apiUmbrella.settings.rate_limits.splice(removeIndex, 1);
+          delete bodyParams.removeIndex;
+        }
+      } else {
+        return errorMessagePayload(400, 'Unknown proxy type.');
+      }
+
+      // Are there not handled parameters still left
+      if (Object.keys(bodyParams).length) {
+        return errorMessagePayload(400, 'Erroneous parameters given.', 'params', bodyParams);
+      }
+
+      // Update the apiUmbrella Proxy Backend document on APInf
+      const result = ProxyBackends.update(proxyBackendId, { $set: proxyBackend });
+      if (!result) {
+        return errorMessagePayload(500, 'Updating proxyBackend failed.');
+      }
+
+      // Get API's just inserted Proxy connection data for response
+      const createdProxyBackend = ProxyBackends.findOne({ apiId });
+      if (!createdProxyBackend) {
+        // The Proxy backend doesn't exist
+        return errorMessagePayload(500, 'Proxy connection for the API is not created.');
+      }
+
+      // OK response with API data
+      return {
+        statusCode: 200,
+        body: {
+          status: 'success',
+          data: createdProxyBackend,
+        },
+      };
+    },
+  },
+  // Delete API's proxy connection
+  delete: {
+    authRequired: true,
+    swagger: {
+      tags: [
+        CatalogV1.swagger.tags.api,
+      ],
+      summary: 'Disconnect an APIs from Proxy.',
+      description: descriptionApis.deleteProxyBackend,
+      parameters: [
+        CatalogV1.swagger.params.apiId,
+      ],
+      responses: {
+        204: {
+          description: 'Proxy connection removed from this API',
+        },
+        400: {
+          description: 'Bad Request. Erroneous or missing parameter.',
+        },
+        401: {
+          description: 'Authentication is required',
+        },
+        403: {
+          description: 'User does not have permission',
+        },
+        404: {
+          description: 'Proxy connection was not found',
+        },
+      },
+      security: [
+        {
+          userSecurityToken: [],
+          userId: [],
+        },
+      ],
+    },
+    action () {
+      // Get ID of API (URL parameter)
+      const apiId = this.urlParams.id;
+      // Get User ID
+      const userId = this.userId;
+
+      // API related checkings
+      // Get API document
+      const api = Apis.findOne(apiId);
+
+      // API must exist
+      if (!api) {
+        // API doesn't exist
+        return errorMessagePayload(404, 'API with specified ID is not found.');
+      }
+
+      // User must be able to manage API
+      if (!api.currentUserCanManage(userId)) {
+        return errorMessagePayload(403, 'User does not have permission to this API.');
+      }
+
+      // Get API's Proxy connection data
+      const proxyBackend = ProxyBackends.findOne({ apiId });
+      if (!proxyBackend) {
+        // The Proxy backend doesn't exist
+        return errorMessagePayload(404, 'Proxy connection for the API is not found.');
+      }
+
+      // Remove the proxy backend
+      // Check if there is proxy backend with certain type
+      if (proxyBackend.type === 'apiUmbrella') {
+        // Delete proxyBackend
+        Meteor.call('deleteProxyBackend', proxyBackend);
+      }
+
+      // OK response with HTTP code only
+      return {
+        statusCode: 204,
+        body: {
+          status: 'success',
+          data: proxyBackend,
+        },
+      };
+    },
+  },
+
 });

--- a/apinf_packages/apis/server/api.js
+++ b/apinf_packages/apis/server/api.js
@@ -1791,23 +1791,23 @@ CatalogV1.addRoute('apis/:id/proxyBackend', {
           // Want to connect to another proxy?
           if (bodyParams.proxyId !== previousProxyBackend.proxyId) {
             // Get proxy document
-            const proxy = Proxies.findOne(bodyParams.proxyId);
+            const currentProxy = Proxies.findOne(bodyParams.proxyId);
 
             // proxy must exist
-            if (!proxy) {
+            if (!currentProxy) {
               return errorMessagePayload(404, 'Proxy with specified ID is not found.');
             }
 
             // proxy type must be apiUmbrella
-            if (proxy.type !== 'apiUmbrella' ) {
-              return errorMessagePayload(404, 'New proxy is wrong type.', 'Type', proxy.type);
+            if (currentProxy.type !== 'apiUmbrella') {
+              return errorMessagePayload(404, 'New proxy is wrong type.', 'Type', currentProxy.type);
             }
             // Delete info about old proxy from apiUmbrella
             const deleteResponse = Meteor.call('deleteProxyBackend',
                                                 previousProxyBackend, false);
             if (deleteResponse) {
-              return errorMessagePayload(500, "Remove proxy backend failed on apiUmbrella",
-                                         "response", deleteResponse);
+              return errorMessagePayload(500, 'Remove proxy backend failed on apiUmbrella',
+                                         'response', deleteResponse);
             }
 
             // Remove old apiUmbrellaId
@@ -1821,8 +1821,8 @@ CatalogV1.addRoute('apis/:id/proxyBackend', {
             // If response has errors object, notify about it
             if (response.errors && response.errors.default) {
               // Notify about error
-              return errorMessagePayload(500, "Adding a backend on apiUmbrella failed",
-                                         "Response", response.errors.default[0]);
+              return errorMessagePayload(500, 'Adding a backend on apiUmbrella failed',
+                                         'Response', response.errors.default[0]);
             }
 
             // Get the API Umbrella ID for newly created backend
@@ -1831,11 +1831,9 @@ CatalogV1.addRoute('apis/:id/proxyBackend', {
             // Attach the API Umbrella backend ID to backend document
             proxyBackend.apiUmbrella.id = newUmbrellaBackendId;
             proxyBackend.proxyId = bodyParams.proxyId;
-
           }
           delete bodyParams.proxyId;
         }
-
       } else {
         return errorMessagePayload(400, 'Unknown proxy type.');
       }

--- a/apinf_packages/proxy_backends/collection/helpers.js
+++ b/apinf_packages/proxy_backends/collection/helpers.js
@@ -44,6 +44,10 @@ ProxyBackends.helpers({
 
     return _.get(this, path, '');
   },
+  backendPrefix () {
+    const path = 'apiUmbrella.url_matches[0].backend_prefix';
+    return _.get(this, path, '');
+  },
   apiSlug () {
     // Get API ID
     const apiId = this.apiId;

--- a/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
+++ b/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
@@ -176,6 +176,7 @@ const descriptionApis = {
   * *apiPort* is port used on API server, default value for https is 443, http is 80.
   * *disableApiKey*, [false | true], true = skip API key requirement in Proxy
   * *rateLimitMode*, [unlimited | custom]
+  * *proxyId* is the id of new proxy, to which API connection is to be changed
 
   #### Parameters related to rate limit ####
 

--- a/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
+++ b/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
@@ -1,4 +1,4 @@
-/* Copyright 2017 Apinf Oy
+/* Copyright 2018 Apinf Oy
 This file is covered by the EUPL license.
 You may obtain a copy of the licence at
 https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
@@ -50,7 +50,7 @@ const descriptionApis = {
   * mandatory: *name* and *url*
   * length of *description* must not exceed 1000 characters
   * value of *lifecycleStatus* must be one of example list
-  * allowed values for parameter *isPublic* are "true" and "false"
+  * *isPublic*, ["true" |"false"]
     * if isPublic is set false, only admin or manager can see the API
   * *documentationUrl* contains a http(s) link to OpenAPI (or Swagger) documentationUrl
   * *externalDocument* contains a http(s) link for other types of documentation
@@ -65,7 +65,7 @@ const descriptionApis = {
   Parameters
   * length of *description* must not exceed 1000 characters
   * value of *lifecycleStatus* must be one of example list
-  * allowed values for parameter *isPublic* are "true" and "false"
+  * *isPublic*, ["true" | "false"]
     * if isPublic is set false, only admin or manager can see the API
   * *documentationUrl* contains a http(s) link to OpenAPI (or Swagger) documentationUrl
   * *externalDocument* contains a http(s) link for other types of documentation
@@ -110,6 +110,89 @@ const descriptionApis = {
   - external documentation links
 
   If match is not found, the operation is considered as failed.
+  `,
+  // --------------------------------------------
+  getProxyBackend: `
+  ### Lists API's Proxy connection information ###
+
+  Lists Proxy connection information of an identified API.
+  When proxy connection exists, returns the Proxy backend settings information (200).
+  In case no proxy connection for API in question exists, returns an error response (404).
+
+  Parameters
+  * *:id* is API id, mandatory (in URL)
+  `,
+  // --------------------------------------------
+  postProxyBackend: `
+  ### Connects an API to a Proxy ###
+
+  Adds API connection to an identified Proxy.
+  The given parameter set depends on the type of selected proxy.
+  On success, returns the updated Proxy connection object.
+
+  Common parameters (M = mandatory)
+  * *:id* is API id (in URL), (M)
+  * *proxyId* is id of the Proxy, to which the API is to be connected, (M)
+
+  #### Default type of proxy is **apiUmbrella**, and the following parameters are needed ####
+  * *frontendPrefix* is a unique identification for
+  summarizing requests and responses done via this proxy connection, (M)
+  * *backendPrefix* is an identification of API on server, (M)
+  * *apiPort* is port used on API server, default value for https is 443, http is 80.
+  * *disableApiKey*, [false | true], true = skip API key requirement in Proxy, default false
+  * *rateLimitMode*, [unlimited | custom], default 'unlimited'
+
+  When parameter *rateLimitMode* has value 'custom', following parameters are needed
+  * *duration*, set request duration in milliseconds
+  * *limitBy*, [apiKey | ip],
+  * *limit*, set number of request
+  * *showLimitInResponseHeaders*, [true | false], is limit shown in response headers or not
+  `,
+  // --------------------------------------------
+  putProxyBackend: `
+  ### Modifies Proxy connection parameters of an API ###
+
+  When an API has a Proxy connection, the connection parameters can be modified.
+  The given parameter set depends on the type of connected proxy.
+  On success, returns the updated Proxy connection object.
+
+  #### Common parameters (M = mandatory) ####
+  * *:id* is API id (in URL), (M)
+
+  ##### Index parameters #####
+  * *editIndex*, indicates, which occurrence of rate limit set is updated
+    * With this parameter at least one of other parameters must be given
+    * new parameter set can be added at the end of list or into a gap in list
+  * *removeIndex*, indicates, which rate limit set is to be removed
+    * no other set related parameters are given with this parameter
+
+  #### apiUmbrella parameters ####
+  The default type of proxy is **apiUmbrella**,
+  at least one of following parameters must be given
+
+  * *frontendPrefix* is a unique identification for
+  summarizing requests and responses done via this proxy connection
+  * *backendPrefix* is an identification of API on server
+  * *apiPort* is port used on API server, default value for https is 443, http is 80.
+  * *disableApiKey*, [false | true], true = skip API key requirement in Proxy
+  * *rateLimitMode*, [unlimited | custom]
+
+  #### Parameters related to rate limit ####
+
+  ##### Rate value parameters #####
+  * *duration*, set request duration in milliseconds
+  * *limitBy*, [apiKey | ip],
+  * *limit*, set number of request
+  * *showLimitInResponseHeaders*, [true | false], is limit shown in response headers or not
+  `,
+  // ---------------------------------------------
+  deleteProxyBackend: `
+  ### Disconnects API from a Proxy ###
+
+  Disconnects an identified API from Proxy by removing Proxy Backend.
+  When proxy connection exists and it is successfully removed,
+  returns an empty response (204).
+  Trying to remove a non-existing proxy connection from API is considered error (404).
   `,
 };
 

--- a/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
+++ b/apinf_packages/rest_apis/lib/descriptions/apis_texts.js
@@ -176,7 +176,6 @@ const descriptionApis = {
   * *apiPort* is port used on API server, default value for https is 443, http is 80.
   * *disableApiKey*, [false | true], true = skip API key requirement in Proxy
   * *rateLimitMode*, [unlimited | custom]
-  * *proxyId* is the id of new proxy, to which API connection is to be changed
 
   #### Parameters related to rate limit ####
 

--- a/apinf_packages/rest_apis/server/catalog.js
+++ b/apinf_packages/rest_apis/server/catalog.js
@@ -1,4 +1,4 @@
-/* Copyright 2017 Apinf Oy
+/* Copyright 2018 Apinf Oy
  This file is covered by the EUPL license.
  You may obtain a copy of the licence at
  https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
@@ -47,6 +47,7 @@ CatalogV1.swagger = {
   tags: {
     authentication: 'Authentication',
     api: 'APIs',
+    proxy: 'Proxies',
   },
   params: {
     api: {
@@ -112,6 +113,29 @@ CatalogV1.swagger = {
       required: false,
       type: 'string',
     },
+    proxyConnectionRequestPost: {
+      name: 'proxyBackendPost',
+      in: 'body',
+      description: 'Proxy connection data',
+      schema: {
+        $ref: '#/definitions/proxyConnectionRequestPost',
+      },
+    },
+    proxyConnectionRequestPut: {
+      name: 'proxyBackendPut',
+      in: 'body',
+      description: 'Proxy connection data',
+      schema: {
+        $ref: '#/definitions/proxyConnectionRequestPut',
+      },
+    },
+    proxyId: {
+      name: 'proxyId',
+      in: 'body',
+      description: 'ID of Proxy',
+      required: true,
+      type: 'string',
+    },
     skip: {
       name: 'skip',
       in: 'query',
@@ -150,7 +174,7 @@ CatalogV1.swagger = {
         lifecycleStatus: {
           type: 'string',
           enum: ['design', 'development', 'testing', 'production', 'deprecated'],
-          example: 'design/development/testing/production/deprecated',
+          example: 'design | development | testing | production | deprecated',
         },
         isPublic: {
           type: 'string',
@@ -205,7 +229,7 @@ CatalogV1.swagger = {
         },
         lifecycleStatus: {
           type: 'string',
-          example: 'design/development/testing/production/deprecated',
+          example: 'design | development | testing | production | deprecated',
         },
         authorizedUserIds: {
           type: 'array',
@@ -308,11 +332,291 @@ CatalogV1.swagger = {
         },
       },
     },
-
+    proxyResponse: {
+      type: 'object',
+      properties: {
+        _id: {
+          type: 'string',
+          example: 'proxy-id-value',
+        },
+        name: {
+          type: 'string',
+          example: 'API Umbrella',
+        },
+        type: {
+          type: 'string',
+          example: 'apiUmbrella',
+        },
+      },
+    },
+    // The proxy schema for POST method
+    proxyConnectionRequestPost: {
+      required: ['frontendPrefix', 'backendPrefix', 'apiPort'],
+      properties: {
+        proxyId: {
+          type: 'string',
+          example: 'id-of-proxy',
+        },
+        frontendPrefix: {
+          type: 'string',
+          example: '/api_name/',
+        },
+        backendPrefix: {
+          type: 'string',
+          example: '/rest/v1/',
+        },
+        apiPort: {
+          type: 'integer',
+          format: 'int32',
+          example: '448',
+        },
+        disableApiKey: {
+          type: 'string',
+          enum: ['true', 'false'],
+          example: 'false',
+        },
+        rateLimitMode: {
+          type: 'string',
+          enum: ['unlimited', 'custom'],
+          example: 'unlimited',
+        },
+        duration: {
+          type: 'integer',
+          format: 'int32',
+          example: '100',
+        },
+        limitBy: {
+          type: 'string',
+          enum: ['apiKey', 'ip'],
+          example: 'apiKey',
+        },
+        limit: {
+          type: 'integer',
+          format: 'int32',
+          example: '500',
+        },
+        showLimitInResponseHeaders: {
+          type: 'string',
+          enum: ['true', 'false'],
+          example: 'false',
+        },
+        allow: {
+          type: 'string',
+          enum: ['deny', 'allow'],
+          example: 'deny',
+        },
+        access: {
+          type: 'string',
+          enum: ['subscribe', 'publish', 'both'],
+          example: 'subscribe',
+        },
+        topic: {
+          type: 'string',
+          example: 'certain-topic',
+        },
+        fromType: {
+          type: 'string',
+          enum: ['clientid', 'username', 'ipaddr'],
+          example: 'clientid',
+        },
+        fromValue: {
+          type: 'string',
+          example: '666',
+        },
+      },
+    },
+    // The proxy schema for PUT method
+    proxyConnectionRequestPut: {
+      properties: {
+        editIndex: {
+          type: 'integer',
+          format: 'int32',
+          example: '1',
+        },
+        removeIndex: {
+          type: 'integer',
+          format: 'int32',
+          example: '3',
+        },
+        frontendPrefix: {
+          type: 'string',
+          example: '/api_name/',
+        },
+        backendPrefix: {
+          type: 'string',
+          example: '/rest/v1/',
+        },
+        apiPort: {
+          type: 'integer',
+          format: 'int32',
+          example: '448',
+        },
+        disableApiKey: {
+          type: 'string',
+          enum: ['true', 'false'],
+          example: 'false',
+        },
+        rateLimitMode: {
+          type: 'string',
+          enum: ['unlimited', 'custom'],
+          example: 'unlimited',
+        },
+        duration: {
+          type: 'integer',
+          format: 'int32',
+          example: '100',
+        },
+        limitBy: {
+          type: 'string',
+          enum: ['apiKey', 'ip'],
+          example: 'apiKey',
+        },
+        limit: {
+          type: 'integer',
+          format: 'int32',
+          example: '500',
+        },
+        showLimitInResponseHeaders: {
+          type: 'string',
+          enum: ['true', 'false'],
+          example: 'false',
+        },
+        allow: {
+          type: 'string',
+          enum: ['deny', 'allow'],
+          example: 'deny',
+        },
+        access: {
+          type: 'string',
+          enum: ['subscribe', 'publish', 'both'],
+          example: 'subscribe',
+        },
+        topic: {
+          type: 'string',
+          example: 'certain-topic',
+        },
+        fromType: {
+          type: 'string',
+          enum: ['clientid', 'username', 'ipaddr'],
+          example: 'clientid',
+        },
+        fromValue: {
+          type: 'string',
+          example: '666',
+        },
+      },
+    },
+    // The proxy backend response schema
+    proxyConnectionResponse: {
+      type: 'object',
+      properties: {
+        _id: {
+          type: 'string',
+          example: 'id-of-proxy-backend',
+        },
+        apiId: {
+          type: 'string',
+          example: 'id-of-connected-api',
+        },
+        proxyId: {
+          type: 'string',
+          example: 'id-of-proxy',
+        },
+        type: {
+          type: 'string',
+          example: 'apiUmberlla',
+        },
+        apiUmbrella: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+              example: 'name-of-connected-api',
+            },
+            frontend_host: {
+              type: 'string',
+              example: 'url-of-proxy',
+            },
+            backend_host: {
+              type: 'string',
+              example: 'url-of-api',
+            },
+            backend_protocol: {
+              type: 'string',
+              example: 'http | https',
+            },
+            servers: {
+              type: 'array',
+              items: {
+                type: 'object',
+                properties: {
+                  host: {
+                    type: 'string',
+                    example: 'host-url-of-api',
+                  },
+                  port: {
+                    type: 'integer',
+                    format: 'int32',
+                    example: '448',
+                  },
+                },
+              },
+            },
+            balance_algorithm: {
+              type: 'string',
+              example: 'least_conn',
+            },
+            settings: {
+              type: 'object',
+              properties: {
+                disable_api_key: {
+                  type: 'string',
+                  example: 'false | true',
+                },
+                rate_limit_mode: {
+                  type: 'string',
+                  example: 'custom | unlimited',
+                },
+                rate_limits: {
+                  type: 'array',
+                  items: {
+                    type: 'object',
+                    properties: {
+                      duration: {
+                        type: 'integer',
+                        format: 'int32',
+                        example: '100',
+                      },
+                      limit_by: {
+                        type: 'string',
+                        example: 'apiKey',
+                      },
+                      limit: {
+                        type: 'integer',
+                        format: 'int32',
+                        example: '99',
+                      },
+                      response_headers: {
+                        type: 'string',
+                        example: 'false | true',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            id: {
+              type: 'string',
+              example: 'id-of-XXX',
+            },
+          },
+        },
+      },
+    },
   },
 };
 
-// Generate Swagger to route /rest/v1/api_catalog.json
+// Generate Swagger to route /rest/v1/catalog.json
 CatalogV1.addSwagger('catalog.json');
 
 export default CatalogV1;

--- a/apinf_packages/rest_apis/server/catalog.js
+++ b/apinf_packages/rest_apis/server/catalog.js
@@ -368,7 +368,7 @@ CatalogV1.swagger = {
         apiPort: {
           type: 'integer',
           format: 'int32',
-          example: '448',
+          example: '443',
         },
         disableApiKey: {
           type: 'string',
@@ -449,7 +449,7 @@ CatalogV1.swagger = {
         apiPort: {
           type: 'integer',
           format: 'int32',
-          example: '448',
+          example: '443',
         },
         disableApiKey: {
           type: 'string',
@@ -557,7 +557,7 @@ CatalogV1.swagger = {
                   port: {
                     type: 'integer',
                     format: 'int32',
-                    example: '448',
+                    example: '443',
                   },
                 },
               },


### PR DESCRIPTION
Closes #3143 

## Changes
- in case API is connected to a proxy, manager sees also backend URL, backend prefix, proxy name and proxy type in API data 
- ability to list apiUmbrella proxy connections of an API
- ability to connect an API to an apiUmbrella Proxy
- ability to disconnect an API from an apiUmbrella Proxy

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
