### PR TITLE
Add API name slug instead of API name into social meta data tags

### DIFF
--- a/apinf_packages/apis/client/lib/router.js
+++ b/apinf_packages/apis/client/lib/router.js
@@ -41,19 +41,23 @@ FlowRouter.route('/apis/:slug/', {
             rel: 'alternate',
             type: 'application/rss+xml',
             href: `/rss/apis/?slug=${slug}`,
-            // title: `RSS Feed for ${api.name}`,
+            // XSS: in title, instead of name, let's use the slug
+            title: `RSS Feed for ${slug}`,
           });
         }
 
         // Set Social Meta Tags
         // Facebook & LinkedIn
         DocHead.addMeta({ property: 'og:image', content: api.logoUrl });
-        // DocHead.addMeta({ property: 'og:title', content: api.name });
+        // XSS: in title, instead of name, let's use the slug
+        DocHead.addMeta({ property: 'og:title', content: slug });
         // DocHead.addMeta({ property: 'og:description', content: api.description });
         DocHead.addMeta({ property: 'og:url', content: window.location.href });
+        
         // Twitter
         DocHead.addMeta({ property: 'twitter:card', content: 'summary' });
-        // DocHead.addMeta({ property: 'twitter:title', content: api.name });
+        // XSS: in title, instead of name, let's use the slug
+        DocHead.addMeta({ property: 'twitter:title', content: slug });
         // DocHead.addMeta({ property: 'twitter:description', content: api.description });
         DocHead.addMeta({ property: 'twitter:image', content: api.logoUrl });
 

--- a/apinf_packages/apis/client/lib/router.js
+++ b/apinf_packages/apis/client/lib/router.js
@@ -53,7 +53,7 @@ FlowRouter.route('/apis/:slug/', {
         DocHead.addMeta({ property: 'og:title', content: slug });
         // DocHead.addMeta({ property: 'og:description', content: api.description });
         DocHead.addMeta({ property: 'og:url', content: window.location.href });
-        
+
         // Twitter
         DocHead.addMeta({ property: 'twitter:card', content: 'summary' });
         // XSS: in title, instead of name, let's use the slug


### PR DESCRIPTION
Closes #3621 

## Changes
- instead of API name, use API name slug in titles of social meta data tags

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
