### PR TITLE
Bringing back branding color picker

### DIFF
--- a/apinf_packages/branding/client/branding.html
+++ b/apinf_packages/branding/client/branding.html
@@ -47,6 +47,7 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
             doc=branding }}
             {{> afQuickField name='siteTitle' id="branding-site-title" }}
             {{> afQuickField name='siteSlogan' id="branding-site-slogan" }}
+            {{> afQuickField name='colors' id="branding-ui-color" }}
             {{> afQuickField name='siteFooter' id="site-footer" }}
             <div id="form-buttons">
               <button id="branding-update-button" type="submit" class="btn btn-primary">

--- a/apinf_packages/branding/collection/schema.js
+++ b/apinf_packages/branding/collection/schema.js
@@ -25,7 +25,7 @@ Branding.schema = new SimpleSchema({
   'colors.primary': {
     type: String,
     optional: true,
-    defaultValue: '#2fa4e7',
+    defaultValue: '#2655C9',
     autoform: {
       type: 'bootstrap-colorpicker',
     },

--- a/apinf_packages/core/client/custom_stylesheet/custom_stylesheet.js
+++ b/apinf_packages/core/client/custom_stylesheet/custom_stylesheet.js
@@ -1,20 +1,24 @@
-/* Copyright 2018 Apinf Oy
+/* Copyright 2017 Apinf Oy
 This file is covered by the EUPL license.
 You may obtain a copy of the licence at
-https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11
+https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11 */
 
+// Meteor packages imports
 import { Template } from 'meteor/templating';
-import { Branding } from '/branding/collection';
+
+// Collection imports
+import Branding from '/apinf_packages/branding/collection';
+
 const tinycolor = require('tinycolor2');
 
 Template.customStylesheet.helpers({
-  mostReadableBackgound () {
+  mostReadableBackground () {
     // Get branding
     const branding = Branding.findOne();
 
     // Placeholder variables
     let backgroundColor;
-    let textColor;
+    let textColor = '#ffffff';
     let lighterBackgroundReadability;
     let darkerBackgroundReadability;
     let mostReadableBackground;
@@ -46,15 +50,15 @@ Template.customStylesheet.helpers({
         // darker background is most readable
         mostReadableBackground = darkerBackground;
       }
-
-      return mostReadableBackground;
     }
+    return mostReadableBackground;
   },
   primaryColor () {
     // Get branding
     const branding = Branding.findOne();
 
-    let primaryColor;
+    // Set default color as blue
+    let primaryColor = '#2fa4e7';
 
     if (branding && branding.colors && branding.colors.primary) {
       primaryColor = branding.colors.primary;
@@ -66,7 +70,8 @@ Template.customStylesheet.helpers({
     // Get branding
     const branding = Branding.findOne();
 
-    let primaryColorText;
+    // Set default color of text as white
+    let primaryColorText = '#ffffff';
 
     if (branding && branding.colors && branding.colors.primaryText) {
       primaryColorText = branding.colors.primaryText;
@@ -74,4 +79,25 @@ Template.customStylesheet.helpers({
 
     return primaryColorText;
   },
-}); */
+  coverPhotoOverlay () {
+    // Get branding
+    const branding = Branding.findOne();
+
+    let coverPhotoOverlay;
+
+    if (branding && branding.colors && branding.colors.coverPhotoOverlay) {
+      coverPhotoOverlay = branding.colors.coverPhotoOverlay;
+    }
+
+    let overlayTransparency = 0;
+
+    if (branding && branding.colors && branding.colors.overlayTransparency) {
+      overlayTransparency = branding.colors.overlayTransparency / 100;
+    }
+
+    const color = tinycolor(coverPhotoOverlay);
+    color.setAlpha(overlayTransparency);
+
+    return color.toRgbString();
+  },
+});

--- a/apinf_packages/core/client/custom_stylesheet/custom_stylesheet.js
+++ b/apinf_packages/core/client/custom_stylesheet/custom_stylesheet.js
@@ -1,0 +1,77 @@
+/* Copyright 2018 Apinf Oy
+This file is covered by the EUPL license.
+You may obtain a copy of the licence at
+https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence-eupl-v11
+
+import { Template } from 'meteor/templating';
+import { Branding } from '/branding/collection';
+const tinycolor = require('tinycolor2');
+
+Template.customStylesheet.helpers({
+  mostReadableBackgound () {
+    // Get branding
+    const branding = Branding.findOne();
+
+    // Placeholder variables
+    let backgroundColor;
+    let textColor;
+    let lighterBackgroundReadability;
+    let darkerBackgroundReadability;
+    let mostReadableBackground;
+
+    if (branding && branding.colors && branding.colors.primary) {
+      // Get background color
+      backgroundColor = branding.colors.primary;
+    }
+
+    if (branding && branding.colors && branding.colors.primaryText) {
+      // Get text color
+      textColor = branding.colors.primaryText;
+    }
+
+    if (backgroundColor && textColor) {
+      // Lighten and darken the background color, for contrast comparison
+      const lighterBackground = tinycolor(backgroundColor).lighten();
+      const darkerBackground = tinycolor(backgroundColor).darken();
+
+      // Get readability values for each combination of background/text color
+      lighterBackgroundReadability = tinycolor.readability(lighterBackground, textColor);
+      darkerBackgroundReadability = tinycolor.readability(darkerBackground, textColor);
+
+      // Select darker or lighter background based on best readability
+      if (lighterBackgroundReadability > darkerBackgroundReadability) {
+        // lighter background is most readable
+        mostReadableBackground = lighterBackground;
+      } else {
+        // darker background is most readable
+        mostReadableBackground = darkerBackground;
+      }
+
+      return mostReadableBackground;
+    }
+  },
+  primaryColor () {
+    // Get branding
+    const branding = Branding.findOne();
+
+    let primaryColor;
+
+    if (branding && branding.colors && branding.colors.primary) {
+      primaryColor = branding.colors.primary;
+    }
+
+    return primaryColor;
+  },
+  primaryColorText () {
+    // Get branding
+    const branding = Branding.findOne();
+
+    let primaryColorText;
+
+    if (branding && branding.colors && branding.colors.primaryText) {
+      primaryColorText = branding.colors.primaryText;
+    }
+
+    return primaryColorText;
+  },
+}); */

--- a/apinf_packages/core/lib/i18n/en.i18n.json
+++ b/apinf_packages/core/lib/i18n/en.i18n.json
@@ -287,6 +287,7 @@
   "branding_panel_title": "Project Branding",
   "branding_projectLogoTitle_logoTitle": "Site Logo",
   "branding_projectCoverPhotoTitle_coverPhotoTitle": "Cover Image",
+  "branding_color_picker": "Brand Color Scheme",
   "branding_projectFeaturedApisMessage_featuredApiMessage": "Select upto 8 APIs to be featured in the Homepage",
   "branding_save": "Save",
   "branding_successMessage": "Branding saved",


### PR DESCRIPTION
Closes #3636

Related PR [#1807](https://github.com/apinf/platform/pull/1807)

## Changes
1.branding.html: added quickfield to bring back color pickers
2. schema.js: changed primary color default value into #2655C9
3. i18n.json: renamed tab as Logo
4. Added file custom_stylesheet.js as commented out.

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
