### PR TITLE
Display API's analytics in API's context

### DIFF
--- a/apinf_packages/apis/client/profile/header/header.html
+++ b/apinf_packages/apis/client/profile/header/header.html
@@ -52,12 +52,14 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
         {{/ if }}
         {{# if currentUser }}
           {{# if api.currentUserCanManage }}
+            <!-- Prepare Analytics only in case API is connected to a Proxy -->
             {{# if proxyBackend }}
-              <li>
-                <a href="{{ pathFor 'apiAnalyticPage' apiSlug=api.slug }}">
+              <li id="api-analytics-tab">
+                <a href="#analytics" data-toggle="tab">
                   {{_ "apiViewAnalytics_button_viewAnalytics" }}
                 </a>
-              </li>
+              </li>              
+              <!-- Monitoring -->
               <li id="api-monitoring-tab">
                 <a href="#monitoring" data-toggle="tab">
                   {{_ "viewApiNavigationMenu_monitoring" }}

--- a/apinf_packages/apis/client/profile/header/header.js
+++ b/apinf_packages/apis/client/profile/header/header.js
@@ -46,7 +46,7 @@ Template.viewApiPageHeader.onRendered(() => {
       numOfVisibleItems = $vlinks.children().length;
       requiredSpace = breakWidths[numOfVisibleItems - 1];
 
-      // There is not enought space
+      // There is not enough space
       if (requiredSpace > availableSpace) {
         $vlinks.children().last().prependTo($hlinks);
         numOfVisibleItems -= 1;

--- a/apinf_packages/apis/client/profile/view.html
+++ b/apinf_packages/apis/client/profile/view.html
@@ -26,6 +26,11 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
 
         {{# if currentUser }}
           {{# if api.currentUserCanManage }}
+            {{# if proxyBackend._id }}
+            <div id="analytics" class="block-wrapper tab-pane fade">
+              {{> apiAnalyticPageBody proxyBackendId=proxyBackend._id }}
+            </div>    
+            {{/ if }}
             <div id="monitoring" class="block-wrapper tab-pane fade">
               {{> apiMonitoring api=api }}
             </div>

--- a/apinf_packages/apis/client/profile/view.js
+++ b/apinf_packages/apis/client/profile/view.js
@@ -61,6 +61,8 @@ Template.viewApi.onCreated(function () {
         // Set a browser tab name
         DocHead.setTitle(`${branding.siteTitle} - ${api.name}`);
       }
+      // initiate timeframe
+      FlowRouter.setQueryParams({ timeframe: 12 });
     }
   });
 });

--- a/apinf_packages/dashboard/client/analytic/body/body.html
+++ b/apinf_packages/dashboard/client/analytic/body/body.html
@@ -6,6 +6,10 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
 <template name="apiAnalyticPageBody">
   <div data-overview-id="{{ proxyBackendId }}" class="block-wrapper">
     <div class="api-settings">
+      <!-- Date picker -->
+      <div style='text-align: right;'>
+        {{> dateRangePicker }}
+      </div>
       <!-- Nav tabs -->
       <ul class="nav nav-tabs">
         <li class="active"><a href="#requests-number" data-toggle="tab">{{_ "apiAnalyticPageBody_title_requestNumber" }}</a></li>

--- a/apinf_packages/dashboard/client/analytic/body/body.js
+++ b/apinf_packages/dashboard/client/analytic/body/body.js
@@ -46,8 +46,8 @@ Template.apiAnalyticPageBody.onCreated(function () {
   instance.lastUpdateTime = new ReactiveVar();
 
   instance.autorun(() => {
-    const timeframe = FlowRouter.getQueryParam('timeframe');
-
+    // Initiate fimeframe to 'Today' if not exists
+    const timeframe = FlowRouter.getQueryParam('timeframe') || 12;
     const queryOption = getDateRange(timeframe);
 
     const params = {

--- a/apinf_packages/dashboard/client/analytic/header/header.html
+++ b/apinf_packages/dashboard/client/analytic/header/header.html
@@ -13,8 +13,5 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
         {{_ "apiAnalyticPageHeader_title" }}
       </h1>
     </div>
-    <div class="col-md-4 dashboard-filter-buttons" style="padding-right: 0;text-align: right;">
-      {{> dateRangePicker }}
-    </div>
   </div>
 </template>

--- a/apinf_packages/dashboard/client/date_range_picker/toolbar.js
+++ b/apinf_packages/dashboard/client/date_range_picker/toolbar.js
@@ -15,7 +15,6 @@ import Apis from '/apinf_packages/apis/collection';
 Template.dateRangePicker.onRendered(() => {
   // Get value of timeframe parameter
   const timeframeParameter = FlowRouter.getQueryParam('timeframe');
-
   // Set value
   this.$('#date-range-picker').val(timeframeParameter);
 });

--- a/apinf_packages/organizations/client/profile/header/header.js
+++ b/apinf_packages/organizations/client/profile/header/header.js
@@ -78,7 +78,7 @@ Template.organizationProfileHeader.onRendered(function () {
       numOfVisibleItems = $vlinks.children().length;
       requiredSpace = breakWidths[numOfVisibleItems - 1];
 
-      // There is not enought space
+      // There is not enough space
       if (requiredSpace > availableSpace) {
         $vlinks.children().last().prependTo($hlinks);
         numOfVisibleItems -= 1;

--- a/apinf_packages/settings/client/menu/menu.js
+++ b/apinf_packages/settings/client/menu/menu.js
@@ -35,7 +35,7 @@ Template.settingsMenu.onRendered(() => {
       numOfVisibleItems = $vlinks.children().length;
       requiredSpace = breakWidths[numOfVisibleItems - 1];
 
-      // There is not enought space
+      // There is not enough space
       if (requiredSpace > availableSpace) {
         $vlinks.children().last().prependTo($hlinks);
         numOfVisibleItems -= 1;


### PR DESCRIPTION
Closes #3660 

## Changes
- when API's Analytics tab is selected on API page, the analytics detail page is opened in same context
- datepicker is included in API analytics detail page

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
