### PR TITLE
Validate API document link while typing it

### DIFF
--- a/apinf_packages/api_docs/client/manage/manage.html
+++ b/apinf_packages/api_docs/client/manage/manage.html
@@ -20,7 +20,9 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
             collection=apiDocsCollection
             doc=apiDoc
             id="apiDocumentationForm"
-            type=formType }}
+            type=formType
+            validation="keyup"
+          }}
 
             <p style="color: #6d859e;">
               {{_ 'manageApiDocumentationModal_hints_uploadApiDocumentation' }}

--- a/apinf_packages/api_docs/client/manage/manage.html
+++ b/apinf_packages/api_docs/client/manage/manage.html
@@ -22,15 +22,17 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
             id="apiDocumentationForm"
             type=formType
             validation="keyup"
-          }}
+            }}
 
             <p style="color: #6d859e;">
               {{_ 'manageApiDocumentationModal_hints_uploadApiDocumentation' }}
               {{_ 'manageApiDocumentationModal_helpText_useHttpsProtocol' }}
             </p>
+            <!-- Drop-down selection for type of documentation (URL/File) -->
             {{> afQuickField name="type" firstOption=false }}
 
             {{#if afFieldValueIs name="type" value="file" }}
+              <!-- selection for file -->
               <div class="documentation-file">
                 {{# unless documentationFile }}
                   {{> manageApiDocumentationModalUploadButton }}
@@ -49,19 +51,26 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
                 {{/ unless }}
               </div>
             {{ else }}
+              <!-- Input field for url -->
               {{> afQuickField name='remoteFileUrl' }}
             {{/ if }}
+
+            <!-- Checkboxes for used methods -->
             {{> afQuickField
               name="submit_methods"
               options=supportedSubmitMethods
               type="select-checkbox-inline"
               noselect=false
             }}
+
+            <!-- Submit button -->
             <div class="text-right">
               <button type="submit" class="btn btn-success btn-success-special" id="save-documentation-link">
                 {{_ "manageApiDocumentationModal_CreateDocumentation_SaveButton" }}
               </button>
             </div>
+
+            <!-- Some entertainment for user, if loading takes time -->
             {{# if fileUploding }}
               {{> spinner }}
             {{/ if }}

--- a/apinf_packages/api_docs/client/manage/manage.js
+++ b/apinf_packages/api_docs/client/manage/manage.js
@@ -7,6 +7,7 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
 import { Mongo } from 'meteor/mongo';
 import { Session } from 'meteor/session';
 import { Template } from 'meteor/templating';
+import { AutoForm } from 'meteor/aldeed:autoform';
 
 // Meteor contributed packages imports
 import { Modal } from 'meteor/peppelg:bootstrap-3-modal';
@@ -144,6 +145,7 @@ Template.manageApiDocumentationModal.events({
     }
   },
   'click #save-documentation-link': function () {
+    AutoForm.resetForm('apiDocumentationForm')
     // Hide modal
     Modal.hide('manageApiDocumentationModal');
   },

--- a/apinf_packages/api_docs/client/manage/manage.js
+++ b/apinf_packages/api_docs/client/manage/manage.js
@@ -145,7 +145,7 @@ Template.manageApiDocumentationModal.events({
     }
   },
   'click #save-documentation-link': function () {
-    AutoForm.resetForm('apiDocumentationForm')
+    AutoForm.resetForm('apiDocumentationForm');
     // Hide modal
     Modal.hide('manageApiDocumentationModal');
   },


### PR DESCRIPTION
Closes #1403 

## Changes
- when providing API documentation link, it is validated on every keyup 
- possible error message because of API documentation input is cleared, when Save button is pressed

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
