### PR TITLE
Organization manager can be added also with username

### DIFF
--- a/apinf_packages/core/lib/i18n/en.i18n.json
+++ b/apinf_packages/core/lib/i18n/en.i18n.json
@@ -641,6 +641,7 @@
   "organizationManagersList_table_title_actions": "Actions",
   "organizationManagersList_table_title_email": "Email",
   "organizationManagersList_table_title_role": "Role",
+  "organizationManagersList_table_title_username": "Username",
   "organizationManagersList_table_title_row_manager": "Manager",
   "organizationManagerForm_successMessage": "New manager added.",
   "organizationManagerForm_userNotRegistered_errorText": "User not currently registered.",

--- a/apinf_packages/organizations/client/managers/list/list.html
+++ b/apinf_packages/organizations/client/managers/list/list.html
@@ -8,14 +8,18 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
     <thead>
       <tr>
         <th>{{_ "organizationManagersList_table_title_role" }}</th>
+        <th>{{_ "organizationManagersList_table_title_username" }}</th>
         <th>{{_ "organizationManagersList_table_title_email" }}</th>
         <th>{{_ "organizationManagersList_table_title_actions" }}</th>
       </tr>
     </thead>
     <tbody>
+      {{# each organizationManagers }}
       <tr>
         <td>{{_ "organizationManagersList_table_title_row_manager" }}</td>
-        {{# each organizationManagers }}
+        <td>
+          {{ username }}
+        </td>
         <td>
           {{ email }}
           {{# unless emailVerified }}
@@ -31,8 +35,8 @@ https://joinup.ec.europa.eu/community/eupl/og_page/european-union-public-licence
           </button>
           {{/ if }}
         </td>
-        {{/ each }}
       </tr>
+      {{/ each }}
     </tbody>
   </table>
 </template>

--- a/apinf_packages/organizations/server/methods.js
+++ b/apinf_packages/organizations/server/methods.js
@@ -71,7 +71,7 @@ Meteor.methods({
     const userByUsername = Accounts.findUserByUsername(manager.user);
 
     // "User" field can be e-mail value or username value
-    const user = userByEmail || userByUsername; 
+    const user = userByEmail || userByUsername;
 
     // No matching in both direction
     if (!user) {

--- a/apinf_packages/organizations/server/methods.js
+++ b/apinf_packages/organizations/server/methods.js
@@ -68,11 +68,10 @@ Meteor.methods({
     // Get any user with matching email
     const userByEmail = Accounts.findUserByEmail(manager.user);
     // Get any user with matching username
-    // const userByUsername = Accounts.findUserByUsername(manager.user);
+    const userByUsername = Accounts.findUserByUsername(manager.user);
 
     // "User" field can be e-mail value or username value
-    // temporarily only with email
-    const user = userByEmail; /* || userByUsername */
+    const user = userByEmail || userByUsername; 
 
     // No matching in both direction
     if (!user) {


### PR DESCRIPTION
Closes #3688

## Changes
- Organization manager can also be added using username
- Organization managers are listed in column, each manager on own row
- Also username is shown in Organization manager list

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
