### PR TITLE
Handled simple-statistics crash on upgradation

### DIFF
--- a/apinf_packages/apis/collection/helpers.js
+++ b/apinf_packages/apis/collection/helpers.js
@@ -112,12 +112,14 @@ Apis.helpers({
       const apiBackendRatingsArray = _.map(apiBackendRatings, rating => { return rating.rating; });
 
       // Get the average (mean) value for API Backend ratings
-      const apiBackendRatingsAverage = ss.mean(apiBackendRatingsArray);
-      // Return average with precision of 2 significant numbers
-      const result = Number(apiBackendRatingsAverage.toPrecision(2));
+      if(apiBackendRatingsArray.length !== 0) {
+      	const apiBackendRatingsAverage = ss.mean(apiBackendRatingsArray);
+      	// Return average with precision of 2 significant numbers
+      	const result = Number(apiBackendRatingsAverage.toPrecision(2));
 
-      if (!isNaN(result)) {
-        return Number(apiBackendRatingsAverage.toPrecision(2));
+      	if (!isNaN(result)) {
+        	return Number(apiBackendRatingsAverage.toPrecision(2));
+      	}
       }
     }
 


### PR DESCRIPTION
Closes #<issue-number>

## Changes
Describe your changes here as a bulleted list:
- application used to crash on "simple-statistics" dependency after version 2.5.0. It was because the "simple-statistics > 2.5.0" "mean function" threw error if  length of argument is 0 and our "helper.js" was not handling the same. Thus, handled it and hence update the simple-statistics to latest one.
- change two

## Developer checklist
This checklist is to be completed by the PR developer:

- [ ] Alternative solutions were compared/discussed before writing code
    - [ ] trade-offs with this solution are considered acceptable
- [ ] Code in this PR adheres to the [project styleguide](CONTRIBUTING.md)
- [ ] This pull request does not decrease project test coverage
- [ ] If the code changes existing database collection(s), migration has been written
- [ ] If UI texts are added or changed, all texts are internationalized

## Reviewer checklist
Reviewed by: @username1

This list is to be completed by the pull request reviewer:
- [ ] Code works as described/expected
- [ ] Code seems to be error free
    - [ ] no browser console errors visible
    - [ ] no server console errors visible
    - [ ] passes CI build
- [ ] Code is written in a way that promotes maintainability
    - [ ] easy to understand
    - [ ] well organized
    - [ ] follows project coding standards and conventions
    - [ ] well documented
